### PR TITLE
Add `-skip-unused` for V program compilation

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -189,7 +189,7 @@ run_odin() {
 run_vlang() {
     echo "Running Vlang" &&
         cd ./v &&
-        v -prod related.v &&
+        v -prod -skip-unused related.v &&
         if [ $HYPER == 1 ]; then
             capture "Vlang" hyperfine -r 5 --show-output "./related"
         else


### PR DESCRIPTION
This PR adds `-skip-unused` option for V program compilation. This will improve performance of the program removing a few arrays allocation and another operation that are not needed for the actual code to run. I don't think this is cheating since this flag will present by default once markused thing become more stable