### PR TITLE
V reset array instead of allocate new

### DIFF
--- a/v/related.v
+++ b/v/related.v
@@ -42,7 +42,9 @@ fn main() {
 	mut tagged_post_count := []int{len: posts.len, cap: posts.len}
 
 	for i, post in posts {
-		unsafe { vmemset(tagged_post_count.data, 0, posts.len * tagged_post_count.element_size) }
+		for j in 0 .. tagged_post_count.len {
+			tagged_post_count[j] = 0
+		}
 
 		for tag in post.tags {
 			for post_index in tag_map[tag] {

--- a/v/related.v
+++ b/v/related.v
@@ -39,7 +39,7 @@ fn main() {
 	}
 
 	mut all_related_posts := []RelatedPosts{cap: posts.len}
-	mut tagged_post_count := []int{len: posts.len, cap: posts.len}
+	mut tagged_post_count := []int{len: posts.len}
 
 	for i, post in posts {
 		for j in 0 .. tagged_post_count.len {

--- a/v/related.v
+++ b/v/related.v
@@ -39,10 +39,10 @@ fn main() {
 	}
 
 	mut all_related_posts := []RelatedPosts{cap: posts.len}
+	mut tagged_post_count := []int{len: posts.len, cap: posts.len}
 
 	for i, post in posts {
-		// slower when preallocated
-		mut tagged_post_count := []int{len: posts.len, cap: posts.len}
+		unsafe { vmemset(tagged_post_count.data, 0, posts.len * tagged_post_count.element_size) }
 
 		for tag in post.tags {
 			for post_index in tag_map[tag] {


### PR DESCRIPTION
It turned out that in `-prod` C compiler already optimizes this to memset (I believe), so no unsafe shenanigans needed