### PR TITLE
[Dart] Remove `late` in models.dart

### DIFF
--- a/dart/models.dart
+++ b/dart/models.dart
@@ -1,21 +1,23 @@
 class Post {
-  late String iD;
-  late String title;
-  late List<String> tags;
+  final String iD;
+  final String title;
+  final List<String> tags;
 
-  Post({required this.iD, required this.title, required this.tags});
+  Post({
+    required this.iD,
+    required this.title,
+    required this.tags,
+  });
 
-  Post.fromJson(dynamic json) {
-    iD = json['_id'];
-    title = json['title'];
-    tags = json['tags'].cast<String>();
-  }
+  factory Post.fromJson(dynamic json) => Post(
+        iD: json['_id'],
+        title: json['title'],
+        tags: List.from(json['tags']),
+      );
 
-  Map<String, dynamic> toJson() {
-    return {
-      '_id': iD,
-      'title': title,
-      'tags': tags,
-    };
-  }
+  Map<String, dynamic> toJson() => {
+        '_id': iD,
+        'title': title,
+        'tags': tags,
+      };
 }


### PR DESCRIPTION
The `late` keyword is not necessary for the `Post` class. `late` variables does also come with a runtime cost since Dart cannot be sure these variables are not `null` and will therefore need to insert a runtime check. So removing the `late` keyword should help on the performance. If not, at least the code gets cleaner.

Another improvement is not using the `.cast()` method on `List<dynamic>`. The `cast()` will add a lazy cast which means it does a casting every time we read from the returned lazy list. It is better to do all the casting in one iteration with `List.from`.