### PR TITLE
Speed up JS implementation

### DIFF
--- a/js/related.js
+++ b/js/related.js
@@ -1,74 +1,65 @@
 
 export function genRelatedPosts(posts) {
-
   // build a map of tags to post indices. tag -> [idx1, idx2, ...]
-  const tagMap = posts.reduce(
-    (acc, post) => {
-      post.tags.forEach((tag) => {
-        if (acc.map[tag]) {
-          acc.map[tag].push(acc.i);
-        } else {
-          acc.map[tag] = [acc.i];
-        }
-      });
-      acc.i++;
-      return acc;
-    },
-    { i: 0, map: {} }
-  );
+  const tagMap = {};
+  posts.forEach((post, i) => {
+    for (const tag of post.tags) {
+      if (tagMap[tag]) {
+        tagMap[tag].push(i);
+      } else {
+        tagMap[tag] = [i];
+      }
+    }
+  });
 
   const taggedPostCount = Array(posts.length);
 
   return Array(posts.length)
     .fill({})
     .map((record, i) => {
+    
+    taggedPostCount.fill(0);
+    let post = posts[i];
 
-      taggedPostCount.fill(0);
-      let post = posts[i];
+    for (const tag of post.tags) {
+      for (const otherIdx of tagMap[tag]) {
+        taggedPostCount[otherIdx]++;
+      }
+    }
 
-      post.tags.forEach((tag) => {
+    taggedPostCount[i] = 0; // exclude self
 
-        tagMap.map[tag].forEach((otherIdx) => {
+    let top5 = Array(5).fill({
+      idx: 0,
+      count: 0,
+    });
 
-          taggedPostCount[otherIdx]++;
+    let minTags = 0;
 
-        });
+    // custom priority queue to find top 5
+    taggedPostCount.forEach((count, i2) => {
 
-      });
+      if (count > minTags) {
+        let pos = 4;
 
-      taggedPostCount[i] = 0; // exclude self
-
-      let top5 = Array(5).fill({
-        idx: 0,
-        count: 0,
-      });
-
-      let minTags = 0;
-
-      // custom priority queue to find top 5
-      taggedPostCount.forEach((count, i2) => {
-
-        if (count > minTags) {
-          let pos = 4;
-
-          while (pos >= 0 && count > top5[pos].count) {
-            pos--;
-          }
-
-          pos++;
-          top5.splice(pos, 0, { idx: i2, count });
-          top5.pop();
-          minTags = top5[4].count;
+        while (pos >= 0 && count > top5[pos].count) {
+          pos--;
         }
 
-      });
+        pos++;
+        top5.splice(pos, 0, { idx: i2, count });
+        top5.pop();
+        minTags = top5[4].count;
+      }
 
-      record._id = post._id;
-      record.title = post.title;
-      record.tags = post.tags;
-      record.related = top5.map((p) => posts[p.idx]);
-
-      return record;
     });
+
+    record._id = post._id;
+    record.title = post.title;
+    record.tags = post.tags;
+    record.related = top5.map((p) => posts[p.idx]);
+
+    return record;
+  });
 }
 


### PR DESCRIPTION
`for..of` loops are usually faster than `Array.prototype` loops. I replaced the `Array.prototype` loops with `for..of` loops when you don't need to access the index.

On my computer for Node 20 it went from 124ms -> 85ms

https://github.com/jinyus/related_post_gen/assets/13814048/b516fd18-1dc5-4431-82af-35d1bdfba36a

