### PR TITLE
Optimize Dart version

### DIFF
--- a/dart/related.dart
+++ b/dart/related.dart
@@ -1,73 +1,90 @@
 import 'dart:convert';
 import 'dart:io';
+import 'dart:typed_data';
 
 import 'models.dart';
 
+// When you have type `Map<String, List<int>>` Dart AOT compiler can't figure
+// out that this container can contain only specific type of lists as
+// values. However if you create an indirection (like
+// `Map<String, TaggedPosts>`) that allows AOT compiler to figure out the type
+// of `map[k].posts` because `TaggedPosts` is a concrete class with a single
+// implementation - so its static type is enough.
+class TaggedPosts {
+  final List<int> posts = [];
+}
+
 void main() {
-  final postsJson = jsonDecode(File('../posts.json').readAsStringSync()) as List<dynamic>;
+  final postsJson =
+      jsonDecode(File('../posts.json').readAsStringSync()) as List<dynamic>;
 
   final posts = postsJson.map(Post.fromJson).toList();
 
   final sw = Stopwatch()..start();
 
-  final tagMap = <String, List<int>>{};
+  final tagMap = <String, TaggedPosts>{};
 
   for (var i = 0; i < posts.length; i++) {
-    posts[i].tags.forEach((tag) {
-      tagMap.update(
-        tag,
-        (list) => list..add(i),
-        ifAbsent: () => [i],
-      );
-    });
+    for (var tag in posts[i].tags) {
+      (tagMap[tag] ??= TaggedPosts()).posts.add(i);
+    }
   }
 
   // preallocate and reuse
-  final taggedPostCount = List.filled(posts.length, 0);
+  final taggedPostCount = Int32List(posts.length);
 
   final allRelatedPosts = List.generate(posts.length, (i) {
     final post = posts[i];
-    taggedPostCount.fillRange(0, posts.length, 0);
 
-    // faster than for in
-    post.tags.forEach((tag) {
-      tagMap[tag]!.forEach((otherPostIdx) {
+    // For now simply inline fillRange which is unfortunately too slow.
+    for (var i = 0; i < posts.length; i++) {
+      taggedPostCount[i] = 0;
+    }
+
+    for (var tag in post.tags) {
+      for (var otherPostIdx in tagMap[tag]!.posts) {
         taggedPostCount[otherPostIdx] += 1;
-      });
-    });
+      }
+    }
 
     taggedPostCount[i] = 0; // don't include self
 
-    final top5 = List.filled(5, (idx: 0, count: 0), growable: true);
+    // Compute max 5 without doing any unnecessary allocations.
+    const topN = 5;
+    final top5 = Int32List(topN * 2); // flattened list of (count, id)
     var minTags = 0;
 
-    // priority queue to keep track of top 5
     for (var i = 0; i < taggedPostCount.length; i++) {
       final count = taggedPostCount[i];
-      if (count > minTags) {
-        var pos = 4;
-
-        while (pos >= 0 && count > top5[pos].count) {
-          pos -= 1;
-        }
-
-        pos += 1;
-
-        top5.insert(pos, (idx: i, count: count));
-        top5.removeLast();
-
-        minTags = top5.last.count;
+      if (count <= minTags) {
+        continue;
       }
+
+      // Find upper bound: pos at which count is larger than current one.
+      var upperBound = (topN - 2) * 2;
+      while (upperBound >= 0 && count > top5[upperBound]) {
+        top5[upperBound + 2] = top5[upperBound];
+        top5[upperBound + 3] = top5[upperBound + 1];
+        upperBound -= 2;
+      }
+      final insertionPos = upperBound + 2;
+      top5[insertionPos] = count;
+      top5[insertionPos + 1] = i;
+
+      minTags = top5[topN * 2 - 2];
     }
 
     return {
       "_id": post.iD,
       "tags": post.tags,
-      "related": top5.map((v) => posts[v.idx]).toList(),
+      "related": [
+        for (var i = 1; i < 10; i += 2) posts[top5[i]],
+      ],
     };
   });
 
   print('Processing time (w/o IO): ${sw.elapsedMilliseconds}ms');
 
-  File('../related_posts_dart.json').writeAsStringSync(jsonEncode(allRelatedPosts));
+  File('../related_posts_dart.json')
+      .writeAsStringSync(jsonEncode(allRelatedPosts));
 }


### PR DESCRIPTION
Main changes: 

* Dart's AOT compiler looses track of concrete types when containers-containing-other-containers are involved, e.g. `Map<K, List<T>>` or `List<List<T>>`. This makes operations wither nested containers slower. To work-around this problem you can simply wrap a nested container into some unique class - this helps AOT compiler to realise what comes from the container.
* Iterable.fillRange is slow - manually inlining it helps (I will file a bug against Dart to fix this).
* `for-in` is better than `forEach` when concrete types are properly known to the compiler (see the first item)
* Rewrote computation of top 5 to avoid unnecessary allocations