### PR TITLE
Numpy optimizations

### DIFF
--- a/python/related_np.py
+++ b/python/related_np.py
@@ -11,11 +11,7 @@ def main():
         posts = json.load(f)
     lap()
 
-    tags = []
-    for post in posts:
-        tags.extend(post["tags"])
-    tags = np.asarray(tags)
-    unique_tags = np.unique(tags)
+    unique_tags = set(tag for post in posts for tag in post["tags"])
 
     tag_map = np.zeros((len(posts), len(unique_tags)), dtype=np.uint16)
 

--- a/python/related_np.py
+++ b/python/related_np.py
@@ -13,7 +13,7 @@ def main():
 
     unique_tags = set(tag for post in posts for tag in post["tags"])
 
-    tag_map = np.zeros((len(posts), len(unique_tags)), dtype=np.uint16)
+    tag_map = np.zeros((len(posts), len(unique_tags)), dtype=np.uint8)
 
     for i, post in enumerate(posts):
         for j, utag in enumerate(unique_tags):

--- a/python/related_np.py
+++ b/python/related_np.py
@@ -12,12 +12,14 @@ def main():
     lap()
 
     unique_tags = set(tag for post in posts for tag in post["tags"])
+    tag_dict = {tag: i for i, tag in enumerate(unique_tags)}
 
     tag_map = np.zeros((len(posts), len(unique_tags)), dtype=np.uint8)
 
     for i, post in enumerate(posts):
-        for j, utag in enumerate(unique_tags):
-            tag_map[i, j] = int(utag in post["tags"])
+        for tag in post["tags"]:
+            j = tag_dict[tag]
+            tag_map[i, j] = 1
 
     # This it the linear algebra, because tag_map is arranged as a matrix,
     # a matmul with a vector accomplishes the same thing as the nested for


### PR DESCRIPTION
- don't create a big tag array to find unique tag list
- smaller dtype makes the matrix take 2x less memory, so it's faster (except on Windows)
- instead of iterating over every tag in the inner loop, iterate over post tags
 
Each change saves 15-25 ms. 