### PR TITLE
Rust/Rust_rayon: use indexes of tag values rather than strings

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -12,5 +12,5 @@ serde = { version = "1.0.188", features = ["derive"] }
 serde_json = "1.0.107"
 
 [profile.release]
-lto = true
+lto = "fat"
 codegen-units = 1

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -1,4 +1,5 @@
 use std::{collections::BinaryHeap, time::Instant};
+use std::borrow::Cow;
 
 use rustc_data_structures::fx::FxHashMap;
 use serde::{Deserialize, Serialize};
@@ -9,20 +10,22 @@ use mimalloc::MiMalloc;
 static GLOBAL: MiMalloc = MiMalloc;
 
 #[derive(Serialize, Deserialize)]
-struct Post {
-    _id: String,
-    title: String,
-    // #[serde(skip_serializing)]
-    tags: Vec<String>,
+struct Post<'a> {
+    #[serde(borrow)]
+    _id: Cow<'a, str>,
+    #[serde(borrow)]
+    title: Cow<'a, str>,
+    #[serde(borrow)]
+    tags: Vec<Cow<'a, str>>,
 }
 
 const NUM_TOP_ITEMS: usize = 5;
 
 #[derive(Serialize)]
 struct RelatedPosts<'a> {
-    _id: &'a String,
-    tags: &'a Vec<String>,
-    related: Vec<&'a Post>,
+    _id: &'a str,
+    tags: &'a Vec<Cow<'a, str>>,
+    related: Vec<&'a Post<'a>>,
 }
 
 #[derive(Eq)]
@@ -71,7 +74,7 @@ fn main() {
 
     let start = Instant::now();
 
-    let mut post_tags_map: FxHashMap<&String, Vec<usize>> = FxHashMap::default();
+    let mut post_tags_map: FxHashMap<&Cow<'_, str>, Vec<usize>> = FxHashMap::default();
 
     for (i, post) in posts.iter().enumerate() {
         for tag in &post.tags {

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -1,5 +1,5 @@
-use std::{collections::BinaryHeap, time::Instant};
 use std::borrow::Cow;
+use std::{collections::BinaryHeap, time::Instant};
 
 use rustc_data_structures::fx::FxHashMap;
 use serde::{Deserialize, Serialize};
@@ -74,11 +74,21 @@ fn main() {
 
     let start = Instant::now();
 
-    let mut post_tags_map: FxHashMap<&Cow<'_, str>, Vec<usize>> = FxHashMap::default();
+    let mut known_tag_idx: FxHashMap<&Cow<'_, str>, usize> = FxHashMap::default();
+    // Indexed by TagIdx
+    let mut post_idx_for_tag: Vec<Vec<usize>> = Vec::new();
+    // Indexed by PostIdx, contains TagIdx values for each post
+    let mut post_tag_idxs: Vec<Vec<usize>> = vec![Vec::new(); posts.len()];
 
     for (i, post) in posts.iter().enumerate() {
         for tag in &post.tags {
-            post_tags_map.entry(tag).or_default().push(i);
+            let next_tag_idx = known_tag_idx.len();
+            let tag_idx = *known_tag_idx.entry(tag).or_insert_with(|| {
+                post_idx_for_tag.push(Vec::new());
+                next_tag_idx
+            });
+            post_idx_for_tag[tag_idx].push(i);
+            post_tag_idxs[i].push(tag_idx);
         }
     }
 
@@ -89,11 +99,9 @@ fn main() {
             // faster than allocating outside the loop
             let mut tagged_post_count = vec![0; posts.len()];
 
-            for tag in &post.tags {
-                if let Some(tag_posts) = post_tags_map.get(tag) {
-                    for &other_post_idx in tag_posts {
-                        tagged_post_count[other_post_idx] += 1;
-                    }
+            for &tag_idx in &post_tag_idxs[idx] {
+                for &other_post_idx in &post_idx_for_tag[tag_idx] {
+                    tagged_post_count[other_post_idx] += 1;
                 }
             }
 

--- a/rust_rayon/Cargo.lock
+++ b/rust_rayon/Cargo.lock
@@ -352,7 +352,6 @@ dependencies = [
  "rustc_data_structures",
  "serde",
  "serde_json",
- "smallstr",
 ]
 
 [[package]]
@@ -485,16 +484,6 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "smallstr"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63b1aefdf380735ff8ded0b15f31aab05daf1f70216c01c02a12926badd1df9d"
-dependencies = [
- "serde",
- "smallvec",
 ]
 
 [[package]]

--- a/rust_rayon/Cargo.toml
+++ b/rust_rayon/Cargo.toml
@@ -15,6 +15,6 @@ serde_json = "1.0.107"
 smallstr = { version = "0.3.0", features = ["serde"] }
 
 [profile.release]
-lto = true
+lto = "fat"
 codegen-units = 1
 debug = "line-tables-only"

--- a/rust_rayon/Cargo.toml
+++ b/rust_rayon/Cargo.toml
@@ -12,7 +12,6 @@ rayon = "1.8.0"
 rustc_data_structures = "0.0.1"
 serde =  { version = "1.0.188", features = ["derive"] }
 serde_json = "1.0.107"
-smallstr = { version = "0.3.0", features = ["serde"] }
 
 [profile.release]
 lto = "fat"

--- a/rust_rayon/src/main.rs
+++ b/rust_rayon/src/main.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::{collections::BinaryHeap, time::Instant};
 
 use rayon::prelude::*;
@@ -9,23 +10,23 @@ use mimalloc::MiMalloc;
 #[global_allocator]
 static GLOBAL: MiMalloc = MiMalloc;
 
-type SString = smallstr::SmallString<[u8; 16]>;
-
 #[derive(Serialize, Deserialize)]
-struct Post {
-    _id: SString,
-    title: String,
-    // #[serde(skip_serializing)]
-    tags: Vec<SString>,
+struct Post<'a> {
+    #[serde(borrow)]
+    _id: Cow<'a, str>,
+    #[serde(borrow)]
+    title: Cow<'a, str>,
+    #[serde(borrow)]
+    tags: Vec<Cow<'a, str>>,
 }
 
 const NUM_TOP_ITEMS: usize = 5;
 
 #[derive(Serialize)]
 struct RelatedPosts<'a> {
-    _id: &'a SString,
-    tags: &'a Vec<SString>,
-    related: Vec<&'a Post>,
+    _id: &'a str,
+    tags: &'a Vec<Cow<'a, str>>,
+    related: Vec<&'a Post<'a>>,
 }
 
 #[derive(Eq)]
@@ -75,7 +76,7 @@ fn main() {
 
     let start = Instant::now();
 
-    let mut known_tag_idx: FxHashMap<&SString, usize> = FxHashMap::default();
+    let mut known_tag_idx: FxHashMap<&str, usize> = FxHashMap::default();
     // Indexed by TagIdx
     let mut post_idx_for_tag: Vec<Vec<usize>> = Vec::new();
     // Indexed by PostIdx, contains TagIdx values for each post


### PR DESCRIPTION
This means we can implement "look up the posts for this tag" as indexing into a list, rather than a hashmap lookup.

For me, it seems to consistently be about 500-1000 microseconds faster

For me, before:

```
Rust:

Benchmark 1: ./target/release/rust
Processing time (w/o IO): 21.957625ms
Processing time (w/o IO): 21.765666ms
Processing time (w/o IO): 21.16875ms
Processing time (w/o IO): 21.034583ms
Processing time (w/o IO): 21.029833ms
Processing time (w/o IO): 21.041625ms
Processing time (w/o IO): 21.03875ms
Processing time (w/o IO): 20.939708ms
Processing time (w/o IO): 21.206417ms
Processing time (w/o IO): 21.370666ms
Processing time (w/o IO): 21.074542ms
Processing time (w/o IO): 21.268959ms
Processing time (w/o IO): 21.151666ms
  Time (mean ± σ):      30.1 ms ±   0.4 ms    [User: 27.4 ms, System: 2.1 ms]
  Range (min … max):    29.7 ms …  31.0 ms    10 runs

Rust Rayon:

Benchmark 1: ./target/release/rust_rayon
Processing time (w/o IO): 3.577ms
Processing time (w/o IO): 3.593917ms
Processing time (w/o IO): 3.564166ms
Processing time (w/o IO): 6.358333ms
Processing time (w/o IO): 3.978958ms
Processing time (w/o IO): 3.566833ms
Processing time (w/o IO): 3.839875ms
Processing time (w/o IO): 3.830833ms
Processing time (w/o IO): 3.687208ms
Processing time (w/o IO): 3.679167ms
Processing time (w/o IO): 4.149209ms
Processing time (w/o IO): 6.864708ms
Processing time (w/o IO): 3.782041ms
  Time (mean ± σ):      15.1 ms ±   1.3 ms    [User: 32.0 ms, System: 6.1 ms]
  Range (min … max):    13.5 ms …  17.5 ms    10 runs
```

And after:

```
Rust:

Benchmark 1: ./target/release/rust
Processing time (w/o IO): 20.051459ms
Processing time (w/o IO): 19.824292ms
Processing time (w/o IO): 20.302958ms
Processing time (w/o IO): 20.187833ms
Processing time (w/o IO): 20.215084ms
Processing time (w/o IO): 19.96525ms
Processing time (w/o IO): 20.044166ms
Processing time (w/o IO): 20.265459ms
Processing time (w/o IO): 20.262167ms
Processing time (w/o IO): 20.293209ms
Processing time (w/o IO): 20.100166ms
Processing time (w/o IO): 19.803583ms
Processing time (w/o IO): 19.902625ms
  Time (mean ± σ):      29.5 ms ±   0.2 ms    [User: 26.5 ms, System: 2.4 ms]
  Range (min … max):    29.2 ms …  29.9 ms    10 runs


Rust Rayon:

Benchmark 1: ./target/release/rust_rayon
Processing time (w/o IO): 4.045333ms
Processing time (w/o IO): 7.885375ms
Processing time (w/o IO): 3.497875ms
Processing time (w/o IO): 3.452ms
Processing time (w/o IO): 3.66275ms
Processing time (w/o IO): 3.383042ms
Processing time (w/o IO): 4.388792ms
Processing time (w/o IO): 3.319ms
Processing time (w/o IO): 3.906291ms
Processing time (w/o IO): 4.066375ms
Processing time (w/o IO): 3.477875ms
Processing time (w/o IO): 3.475834ms
Processing time (w/o IO): 3.349167ms
  Time (mean ± σ):      14.3 ms ±   0.8 ms    [User: 29.4 ms, System: 5.7 ms]
  Range (min … max):    13.4 ms …  16.0 ms    10 runs
```