### PR TITLE
Python: use scipy sparse array over numpy dense array

### DIFF
--- a/python/related_np.py
+++ b/python/related_np.py
@@ -3,6 +3,7 @@ from timing import lap, finish
 lap()
 import ujson as json
 import numpy as np
+from scipy.sparse import coo_array
 
 
 def main():
@@ -14,20 +15,24 @@ def main():
     unique_tags = set(tag for post in posts for tag in post["tags"])
     tag_dict = {tag: i for i, tag in enumerate(unique_tags)}
 
-    tag_map = np.zeros((len(posts), len(unique_tags)), dtype=np.uint8)
-
+    ij = []
     for i, post in enumerate(posts):
         for tag in post["tags"]:
             j = tag_dict[tag]
-            tag_map[i, j] = 1
+            ij.append((i, j))
+    tag_map = coo_array((np.ones(len(ij), dtype=np.uint8), zip(*ij)),
+                        shape=(len(posts), len(unique_tags)),
+                        dtype=np.uint8)
+
+    tag_map = tag_map.tocsr()
 
     # This it the linear algebra, because tag_map is arranged as a matrix,
     # a matmul with a vector accomplishes the same thing as the nested for
     # loop and sum operation in one function
-    # call using highly optimized BLAS routines.
 
-    relatedness = np.squeeze(np.dot(tag_map[:, None, :], tag_map[:, :, None]))
-    np.fill_diagonal(relatedness, 0)
+    relatedness = tag_map @ tag_map.T
+    relatedness.setdiag(0)
+    relatedness = relatedness.todense()
     related_posts = np.flip(
         np.argsort(relatedness, axis=1, kind="stable")[:, -5:], axis=1
     )

--- a/python/related_np.py
+++ b/python/related_np.py
@@ -32,18 +32,18 @@ def main():
 
     relatedness = tag_map @ tag_map.T
     relatedness.setdiag(0)
-    relatedness = relatedness.todense()
-    related_posts = np.flip(
-        np.argsort(relatedness, axis=1, kind="stable")[:, -5:], axis=1
-    )
 
     all_related = []
     for i, post in enumerate(posts):
+        data = relatedness.data[relatedness.indptr[i]: relatedness.indptr[i + 1]]
+        top5_among_nonzeros = np.flip(np.argsort(data, kind="stable")[-5:])
+        top5 = relatedness.indices[relatedness.indptr[i]: relatedness.indptr[i + 1]][top5_among_nonzeros]
+
         all_related.append(
             {
                 "_id": post["_id"],
                 "tags": post["tags"],
-                "related": [posts[idx].copy() for idx in related_posts[i, :]],
+                "related": [posts[idx].copy() for idx in top5],
             }
         )
 

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,2 +1,3 @@
 numpy
+scipy
 ujson

--- a/run.sh
+++ b/run.sh
@@ -116,7 +116,7 @@ run_python_np() {
             python3 -m venv venv
         fi
     source venv/bin/activate &&
-        (pip freeze | grep numpy && pip freeze | grep ujson) || pip install -r requirements.txt &&
+        (pip freeze | grep numpy && pip freeze | grep scipy && pip freeze | grep ujson) || pip install -r requirements.txt &&
         if [ $HYPER == 1 ]; then
             capture "Numpy" hyperfine -r 5 --show-output "python3 ./related_np.py"
         else


### PR DESCRIPTION
As not every post has every tag, the post-tag matrix is sparse (has many 0s). Matrix multiplication is faster if we rely on this.
1. moving from numpy to scipy processing jumps from 500-700 ms to 270-280 ms;
2. using internals of sparse array representation (Compressed Space Row), sorting for top5 wins additional 40ms;

commit | import | compile | input | process | output | total
-- | -- | -- | -- | -- | -- | --
0: copy numpy matrix… | 47.52±0.88 | 0.00±0 | 3.548±0.023 | 476.7±4.3 | 18.25±0.98 | 546.1±5.8
1: use scipy sparse … | 81.6±5.2 | 0.00±0 | 3.571±0.082 | 276.0±3.9 | 18.8±2.0 | 380.0±5.8
2: sort results dire… | 78.2±1.2 | 0.00±0 | 3.530±0.035 | 228.4±7.8 | 18.5±1.1 | 328.6±8.4

Should this stay a separate implementation (and have a new run.sh entry), or should it replace the Numpy implementation? The logical idea is the same but faster, but with more dependencies (even import takes extra 30ms).
