### PR TITLE
returned default malloc; replaced Cow

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -183,16 +183,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cdc71e17332e86d2e1d38c1f99edcb6288ee11b815fb1a4b049eaa2114d369b"
 
 [[package]]
-name = "libmimalloc-sys"
-version = "0.1.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3979b5c37ece694f1f5e51e7ecc871fdb0f517ed04ee45f88d15d6d553cb9664"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -230,15 +220,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "mimalloc"
-version = "0.1.39"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa01922b5ea280a911e323e4d2fd24b7fe5cc4042e0d2cda3c40775cdc4bdc9c"
-dependencies = [
- "libmimalloc-sys",
 ]
 
 [[package]]
@@ -326,7 +307,6 @@ dependencies = [
 name = "rust"
 version = "0.1.0"
 dependencies = [
- "mimalloc",
  "rustc_data_structures",
  "serde",
  "serde_json",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-mimalloc = "0.1.39"
 rustc_data_structures = "0.0.1"
 serde = { version = "1.0.188", features = ["derive"] }
 serde_json = "1.0.107"

--- a/rust_con/Cargo.lock
+++ b/rust_con/Cargo.lock
@@ -183,16 +183,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cdc71e17332e86d2e1d38c1f99edcb6288ee11b815fb1a4b049eaa2114d369b"
 
 [[package]]
-name = "libmimalloc-sys"
-version = "0.1.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3979b5c37ece694f1f5e51e7ecc871fdb0f517ed04ee45f88d15d6d553cb9664"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -230,15 +220,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "mimalloc"
-version = "0.1.39"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa01922b5ea280a911e323e4d2fd24b7fe5cc4042e0d2cda3c40775cdc4bdc9c"
-dependencies = [
- "libmimalloc-sys",
 ]
 
 [[package]]
@@ -346,13 +327,11 @@ dependencies = [
 name = "rust_rayon"
 version = "0.1.0"
 dependencies = [
- "mimalloc",
  "num_cpus",
  "rayon",
  "rustc_data_structures",
  "serde",
  "serde_json",
- "smallstr",
 ]
 
 [[package]]
@@ -485,16 +464,6 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "smallstr"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63b1aefdf380735ff8ded0b15f31aab05daf1f70216c01c02a12926badd1df9d"
-dependencies = [
- "serde",
- "smallvec",
 ]
 
 [[package]]

--- a/rust_con/Cargo.toml
+++ b/rust_con/Cargo.toml
@@ -6,13 +6,11 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-mimalloc = "0.1.39"
 num_cpus = "1.16.0"
 rayon = "1.8.0"
 rustc_data_structures = "0.0.1"
 serde =  { version = "1.0.188", features = ["derive"] }
 serde_json = "1.0.107"
-smallstr = { version = "0.3.0", features = ["serde"] }
 
 [profile.release]
 lto = true

--- a/rust_con/src/main.rs
+++ b/rust_con/src/main.rs
@@ -1,37 +1,32 @@
 use std::{collections::BinaryHeap, time::Instant};
+use std::borrow::Cow;
 
 use rayon::prelude::*;
 use rustc_data_structures::fx::FxHashMap;
 use serde::{Deserialize, Serialize};
 use serde_json::from_str;
 
-use mimalloc::MiMalloc;
-#[global_allocator]
-static GLOBAL: MiMalloc = MiMalloc;
-
-type SString = smallstr::SmallString<[u8; 16]>;
-
 #[derive(Serialize, Deserialize)]
-struct Post {
-    _id: SString,
-    title: String,
+struct Post<'a> {
+    _id: Cow<'a,str>,
+    title: Cow<'a,str>,
     // #[serde(skip_serializing)]
-    tags: Vec<SString>,
+    tags: Vec<Cow<'a,str>>,
 }
 
 const NUM_TOP_ITEMS: usize = 5;
 
 #[derive(Serialize)]
 struct RelatedPosts<'a> {
-    _id: &'a SString,
-    tags: &'a Vec<SString>,
-    related: Vec<&'a Post>,
+    _id: &'a Cow<'a,str>,
+    tags: &'a Vec<Cow<'a,str>>,
+    related: Vec<&'a Post<'a>>,
 }
 
 #[derive(Eq)]
 struct PostCount {
-    post: usize,
-    count: usize,
+    post: u32,
+    count: u32,
 }
 
 impl std::cmp::PartialEq for PostCount {
@@ -71,15 +66,15 @@ fn least_n<T: Ord>(n: usize, mut from: impl Iterator<Item = T>) -> impl Iterator
 fn main() {
     let json_str = std::fs::read_to_string("../posts.json").unwrap();
     let posts: Vec<Post> = from_str(&json_str).unwrap();
-    let num_cpus = num_cpus::get_physical(); // does IO to get num_cpus
+    let num_cpus = num_cpus::get_physical() ; // does IO to get num_cpus
 
     let start = Instant::now();
 
-    let mut post_tags_map: FxHashMap<&str, Vec<usize>> = FxHashMap::default();
+    let mut post_tags_map: FxHashMap<&str, Vec<u32>> = FxHashMap::default();
 
     for (i, post) in posts.iter().enumerate() {
         for tag in &post.tags {
-            post_tags_map.entry(tag).or_default().push(i);
+            post_tags_map.entry(tag.as_ref()).or_default().push(i as u32);
         }
     }
 
@@ -97,9 +92,9 @@ fn main() {
                 let mut tagged_post_count = vec![0; posts.len()];
 
                 for tag in &post.tags {
-                    if let Some(tag_posts) = post_tags_map.get(tag.as_str()) {
+                    if let Some(tag_posts) = post_tags_map.get(tag.as_ref()) {
                         for &other_post_idx in tag_posts {
-                            tagged_post_count[other_post_idx] += 1;
+                            tagged_post_count[other_post_idx as usize] += 1;
                         }
                     }
                 }
@@ -111,9 +106,9 @@ fn main() {
                     tagged_post_count
                         .into_iter()
                         .enumerate()
-                        .map(|(post, count)| PostCount { post, count }),
+                        .map(|(post, count)| PostCount { post:post as u32, count }),
                 );
-                let related = top.map(|it| &posts[it.post]).collect();
+                let related = top.map(|it| &posts[it.post as usize]).collect();
 
                 RelatedPosts {
                     _id: &post._id,


### PR DESCRIPTION
Rust:
changed String (SString) to Cow<'a,str>, should help cache locality / memory-size, memory allocation-pressure (for longer strings if any were present)

removed mini-alloc, as the only thing being allocated is the temporary vec, and since it's always the same size each iteration, it shouldn't have any difference how the allocator works.

changed usize to u32 (saw a few ms speedup; assume due to cache locality)
