### PR TITLE
Assorted improvements to Rust benchmarks

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -183,6 +183,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cdc71e17332e86d2e1d38c1f99edcb6288ee11b815fb1a4b049eaa2114d369b"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3979b5c37ece694f1f5e51e7ecc871fdb0f517ed04ee45f88d15d6d553cb9664"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -220,6 +230,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa01922b5ea280a911e323e4d2fd24b7fe5cc4042e0d2cda3c40775cdc4bdc9c"
+dependencies = [
+ "libmimalloc-sys",
 ]
 
 [[package]]
@@ -307,6 +326,7 @@ dependencies = [
 name = "rust"
 version = "0.1.0"
 dependencies = [
+ "mimalloc",
  "rustc_data_structures",
  "serde",
  "serde_json",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -310,6 +310,7 @@ dependencies = [
  "rustc_data_structures",
  "serde",
  "serde_json",
+ "smallstr",
 ]
 
 [[package]]
@@ -442,6 +443,16 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "smallstr"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b1aefdf380735ff8ded0b15f31aab05daf1f70216c01c02a12926badd1df9d"
+dependencies = [
+ "serde",
+ "smallvec",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -13,5 +13,5 @@ serde_json = "1.0.107"
 smallstr = { version = "0.3.0", features = ["serde"] }
 
 [profile.release]
-lto = true
+lto = "fat"
 codegen-units = 1

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 rustc_data_structures = "0.0.1"
 serde = { version = "1.0.188", features = ["derive"] }
 serde_json = "1.0.107"
+smallstr = { version = "0.3.0", features = ["serde"] }
 
 [profile.release]
 lto = true

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+mimalloc = "0.1.39"
 rustc_data_structures = "0.0.1"
 serde = { version = "1.0.188", features = ["derive"] }
 serde_json = "1.0.107"

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -25,8 +25,8 @@ struct RelatedPosts<'a> {
 
 #[derive(Eq)]
 struct PostCount {
-    post: u32,
-    count: u32,
+    post: u16,
+    count: u16,
 }
 
 impl std::cmp::PartialEq for PostCount {
@@ -72,11 +72,11 @@ fn main() {
 
     let start = Instant::now();
 
-    let mut post_tags_map: FxHashMap<&SString, Vec<usize>> = FxHashMap::default();
+    let mut post_tags_map: FxHashMap<&SString, Vec<u16>> = FxHashMap::default();
 
     for (post_idx, post) in posts.iter().enumerate() {
         for tag in post.tags.iter() {
-            post_tags_map.entry(tag).or_default().push(post_idx as u32);
+            post_tags_map.entry(tag).or_default().push(post_idx as u16);
         }
     }
 
@@ -85,10 +85,7 @@ fn main() {
         .enumerate()
         .map(|(post_idx, post)| {
             // faster than allocating outside the loop
-            let mut tagged_post_count = vec![0u32; posts.len()];
-            // tagged_post_count.fill(0u32);
-            // tagged_post_count.clear();
-            // tagged_post_count.extend(std::iter::repeat(0).take(0));
+            let mut tagged_post_count = vec![0u16; posts.len()];
 
             for tag in post.tags.iter() {
                 if let Some(tag_posts) = post_tags_map.get(tag) {
@@ -105,7 +102,10 @@ fn main() {
                 tagged_post_count
                     .iter()
                     .enumerate()
-                    .map(|(post, &count)| PostCount { post: post as u32, count }),
+                    .map(|(post, &count)| PostCount {
+                        post: post as u16,
+                        count,
+                    }),
             );
             let related = top.map(|it| &posts[it.post as usize]).collect();
 

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -29,18 +29,21 @@ struct PostCount {
 }
 
 impl std::cmp::PartialEq for PostCount {
+    #[inline]
     fn eq(&self, other: &Self) -> bool {
         self.count == other.count
     }
 }
 
 impl std::cmp::PartialOrd for PostCount {
+    #[inline]
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         Some(self.cmp(other))
     }
 }
 
 impl std::cmp::Ord for PostCount {
+    #[inline]
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         // reverse order
         other.count.cmp(&self.count)

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -4,6 +4,10 @@ use rustc_data_structures::fx::FxHashMap;
 use serde::{Deserialize, Serialize};
 use serde_json::from_str;
 
+use mimalloc::MiMalloc;
+#[global_allocator]
+static GLOBAL: MiMalloc = MiMalloc;
+
 type SString = smallstr::SmallString<[u8; 16]>;
 
 #[derive(Serialize, Deserialize)]

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -1,25 +1,26 @@
 use std::{collections::BinaryHeap, time::Instant};
-use std::borrow::Cow;
 
 use rustc_data_structures::fx::FxHashMap;
 use serde::{Deserialize, Serialize};
 use serde_json::from_str;
 
+type SString = smallstr::SmallString<[u8; 16]>;
+
 #[derive(Serialize, Deserialize)]
-struct Post<'a> {
-    _id: Cow<'a,str>,
-    title: Cow<'a,str>,
+struct Post {
+    _id: SString,
+    title: String,
     // #[serde(skip_serializing)]
-    tags: Vec<Cow<'a,str>>,
+    tags: Vec<SString>,
 }
 
 const NUM_TOP_ITEMS: usize = 5;
 
 #[derive(Serialize)]
 struct RelatedPosts<'a> {
-    _id: &'a Cow<'a,str>,
-    tags: &'a Vec<Cow<'a,str>>,
-    related: Vec<&'a Post<'a>>,
+    _id: &'a SString,
+    tags: &'a Vec<SString>,
+    related: Vec<&'a Post>,
 }
 
 #[derive(Eq)]
@@ -71,7 +72,7 @@ fn main() {
 
     let start = Instant::now();
 
-    let mut post_tags_map: FxHashMap<&Cow<'_,str>, Vec<u32>> = FxHashMap::default();
+    let mut post_tags_map: FxHashMap<&SString, Vec<usize>> = FxHashMap::default();
 
     for (post_idx, post) in posts.iter().enumerate() {
         for tag in post.tags.iter() {

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::{collections::BinaryHeap, time::Instant};
 
 use rustc_data_structures::fx::FxHashMap;
@@ -11,9 +12,10 @@ static GLOBAL: MiMalloc = MiMalloc;
 type SString = smallstr::SmallString<[u8; 16]>;
 
 #[derive(Serialize, Deserialize)]
-struct Post {
+struct Post<'a> {
     _id: SString,
-    title: String,
+    #[serde(borrow)]
+    title: Cow<'a, str>,
     // #[serde(skip_serializing)]
     tags: Vec<SString>,
 }
@@ -24,7 +26,7 @@ const NUM_TOP_ITEMS: usize = 5;
 struct RelatedPosts<'a> {
     _id: &'a str,
     tags: &'a [SString],
-    related: Vec<&'a Post>,
+    related: Vec<&'a Post<'a>>,
 }
 
 #[derive(Eq)]

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -119,11 +119,14 @@ fn main() {
 
     let end = Instant::now();
 
+    // I have no explanation for why, but doing this before the print improves performance pretty
+    // significantly (15%) when using slices in the hashmap key and RelatedPosts
+    let json_str = serde_json::to_string(&related_posts).unwrap();
+
     print!(
         "Processing time (w/o IO): {:?}\n",
         end.duration_since(start)
     );
 
-    let json_str = serde_json::to_string(&related_posts).unwrap();
     std::fs::write("../related_posts_rust.json", json_str).unwrap();
 }

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -18,8 +18,8 @@ const NUM_TOP_ITEMS: usize = 5;
 
 #[derive(Serialize)]
 struct RelatedPosts<'a> {
-    _id: &'a SString,
-    tags: &'a Vec<SString>,
+    _id: &'a str,
+    tags: &'a [SString],
     related: Vec<&'a Post>,
 }
 
@@ -72,7 +72,7 @@ fn main() {
 
     let start = Instant::now();
 
-    let mut post_tags_map: FxHashMap<&SString, Vec<u16>> = FxHashMap::default();
+    let mut post_tags_map: FxHashMap<&str, Vec<u16>> = FxHashMap::default();
 
     for (post_idx, post) in posts.iter().enumerate() {
         for tag in post.tags.iter() {
@@ -88,7 +88,7 @@ fn main() {
             let mut tagged_post_count = vec![0u16; posts.len()];
 
             for tag in post.tags.iter() {
-                if let Some(tag_posts) = post_tags_map.get(tag) {
+                if let Some(tag_posts) = post_tags_map.get::<str>(tag.as_ref()) {
                     for other_post_idx in tag_posts.iter() {
                         tagged_post_count[*other_post_idx as usize] += 1;
                     }

--- a/rust_con/Cargo.lock
+++ b/rust_con/Cargo.lock
@@ -183,6 +183,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cdc71e17332e86d2e1d38c1f99edcb6288ee11b815fb1a4b049eaa2114d369b"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3979b5c37ece694f1f5e51e7ecc871fdb0f517ed04ee45f88d15d6d553cb9664"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -220,6 +230,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa01922b5ea280a911e323e4d2fd24b7fe5cc4042e0d2cda3c40775cdc4bdc9c"
+dependencies = [
+ "libmimalloc-sys",
 ]
 
 [[package]]
@@ -327,6 +346,7 @@ dependencies = [
 name = "rust_rayon"
 version = "0.1.0"
 dependencies = [
+ "mimalloc",
  "num_cpus",
  "rayon",
  "rustc_data_structures",

--- a/rust_con/Cargo.lock
+++ b/rust_con/Cargo.lock
@@ -332,6 +332,7 @@ dependencies = [
  "rustc_data_structures",
  "serde",
  "serde_json",
+ "smallstr",
 ]
 
 [[package]]
@@ -464,6 +465,16 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "smallstr"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b1aefdf380735ff8ded0b15f31aab05daf1f70216c01c02a12926badd1df9d"
+dependencies = [
+ "serde",
+ "smallvec",
 ]
 
 [[package]]

--- a/rust_con/Cargo.toml
+++ b/rust_con/Cargo.toml
@@ -11,6 +11,7 @@ rayon = "1.8.0"
 rustc_data_structures = "0.0.1"
 serde =  { version = "1.0.188", features = ["derive"] }
 serde_json = "1.0.107"
+smallstr = { version = "0.3.0", features = ["serde"] }
 
 [profile.release]
 lto = true

--- a/rust_con/Cargo.toml
+++ b/rust_con/Cargo.toml
@@ -15,6 +15,6 @@ serde_json = "1.0.107"
 smallstr = { version = "0.3.0", features = ["serde"] }
 
 [profile.release]
-lto = true
+lto = "thin"
 codegen-units = 1
 debug = "line-tables-only"

--- a/rust_con/Cargo.toml
+++ b/rust_con/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+mimalloc = "0.1.39"
 num_cpus = "1.16.0"
 rayon = "1.8.0"
 rustc_data_structures = "0.0.1"

--- a/rust_con/src/main.rs
+++ b/rust_con/src/main.rs
@@ -30,18 +30,21 @@ struct PostCount {
 }
 
 impl std::cmp::PartialEq for PostCount {
+    #[inline]
     fn eq(&self, other: &Self) -> bool {
         self.count == other.count
     }
 }
 
 impl std::cmp::PartialOrd for PostCount {
+    #[inline]
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         Some(self.cmp(other))
     }
 }
 
 impl std::cmp::Ord for PostCount {
+    #[inline]
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         // reverse order
         other.count.cmp(&self.count)

--- a/rust_con/src/main.rs
+++ b/rust_con/src/main.rs
@@ -25,8 +25,8 @@ struct RelatedPosts<'a> {
 
 #[derive(Eq)]
 struct PostCount {
-    post: u32,
-    count: u32,
+    post: u16,
+    count: u16,
 }
 
 impl std::cmp::PartialEq for PostCount {
@@ -73,11 +73,11 @@ fn main() {
 
     let start = Instant::now();
 
-    let mut post_tags_map: FxHashMap<&str, Vec<u32>> = FxHashMap::default();
+    let mut post_tags_map: FxHashMap<&str, Vec<u16>> = FxHashMap::default();
 
     for (i, post) in posts.iter().enumerate() {
         for tag in &post.tags {
-            post_tags_map.entry(tag.as_ref()).or_default().push(i as u32);
+            post_tags_map.entry(tag).or_default().push(i as u16);
         }
     }
 
@@ -109,7 +109,10 @@ fn main() {
                     tagged_post_count
                         .into_iter()
                         .enumerate()
-                        .map(|(post, count)| PostCount { post:post as u32, count }),
+                        .map(|(post, count)| PostCount {
+                            post: post as u16,
+                            count,
+                        }),
                 );
                 let related = top.map(|it| &posts[it.post as usize]).collect();
 

--- a/rust_con/src/main.rs
+++ b/rust_con/src/main.rs
@@ -6,6 +6,10 @@ use rustc_data_structures::fx::FxHashMap;
 use serde::{Deserialize, Serialize};
 use serde_json::from_str;
 
+use mimalloc::MiMalloc;
+#[global_allocator]
+static GLOBAL: MiMalloc = MiMalloc;
+
 type SString = smallstr::SmallString<[u8; 16]>;
 
 #[derive(Serialize, Deserialize)]

--- a/rust_con/src/main.rs
+++ b/rust_con/src/main.rs
@@ -18,8 +18,8 @@ const NUM_TOP_ITEMS: usize = 5;
 
 #[derive(Serialize)]
 struct RelatedPosts<'a> {
-    _id: &'a Cow<'a,str>,
-    tags: &'a Vec<Cow<'a,str>>,
+    _id: &'a str,
+    tags: &'a [Cow<'a, str>],
     related: Vec<&'a Post<'a>>,
 }
 

--- a/rust_con/src/main.rs
+++ b/rust_con/src/main.rs
@@ -15,6 +15,7 @@ type SString = smallstr::SmallString<[u8; 16]>;
 #[derive(Serialize, Deserialize)]
 struct Post<'a> {
     _id: SString,
+    #[serde(borrow)]
     title: Cow<'a, str>,
     // #[serde(skip_serializing)]
     tags: Vec<SString>,


### PR DESCRIPTION
In no particular order

* Bring back `mimalloc` in both cases
* Bring back `smallstr` for ID and tags; it's faster than borrowing from the original JSON blob, presumably due to better cache locality
  * Also port that optimization to `rust` (previously it was only used in `rust_con`)
  * Once `compact_str` gets another release, it will provide a significant performance improvement over `smallstr`, but I don't expect pulling a dependency from github instead of crates.io is something you want
* Actually borrow titles
* Use `u16`s instead of `usize`s for post index and count (someone changed them to `u32`s earlier today)
* Use slices for references to strings and vecs
* Use thin LTO for `rust_con`; explicitly use fat for `rust`
* Mark trivial functions (`eq()`, `partial_cmp()`, and `cmp()` on `PostCount`) with `#[inline]` markers; this makes them eligible for cross-crate inlining, which is relevant when they're called from e.g. the std library

Each of these made a small but repeatable change, at least on my local machine