### PR TITLE
CSharp AOT publish.

### DIFF
--- a/csharp/Program.cs
+++ b/csharp/Program.cs
@@ -2,6 +2,15 @@
 using System.Text.Json.Serialization;
 
 
+[JsonSourceGenerationOptions(WriteIndented = true)]
+[JsonSerializable(typeof(List<Post>))]
+[JsonSerializable(typeof(Post))]
+[JsonSerializable(typeof(RelatedPosts[]))]
+[JsonSerializable(typeof(RelatedPosts))]
+internal partial class PostSourceGenerationContext : JsonSerializerContext
+{
+}
+
 public struct Post
 {
     [JsonPropertyName("_id")]
@@ -31,7 +40,7 @@ public class Program
     public static void Main(string[] args)
     {
         const int topN = 5;
-        var posts = JsonSerializer.Deserialize<List<Post>>(File.ReadAllText(@"../posts.json"));
+        var posts = JsonSerializer.Deserialize<List<Post>>(File.ReadAllText(@"../posts.json"), PostSourceGenerationContext.Default.ListPost);
 
         var start = DateTime.Now;
 
@@ -113,6 +122,6 @@ public class Program
 
         Console.WriteLine("Processing time (w/o IO): {0}ms", (end - start).TotalMilliseconds);
 
-        File.WriteAllText(@"../related_posts_csharp.json", JsonSerializer.Serialize(allRelatedPosts));
+        File.WriteAllText(@"../related_posts_csharp.json", JsonSerializer.Serialize(allRelatedPosts, PostSourceGenerationContext.Default.RelatedPostsArray));
     }
 }

--- a/csharp/Properties/PublishProfiles/FolderProfile.pubxml
+++ b/csharp/Properties/PublishProfiles/FolderProfile.pubxml
@@ -1,0 +1,13 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+https://go.microsoft.com/fwlink/?LinkID=208121.
+-->
+<Project>
+  <PropertyGroup>
+    <Configuration>Release</Configuration>
+    <Platform>Any CPU</Platform>
+    <PublishDir>bin\Release\net8.0\publish\</PublishDir>
+    <PublishProtocol>FileSystem</PublishProtocol>
+    <_TargetId>Folder</_TargetId>
+  </PropertyGroup>
+</Project>

--- a/csharp/related.csproj
+++ b/csharp/related.csproj
@@ -2,9 +2,14 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+	  
+	  <PublishAot>true</PublishAot>
+	  <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+	  <InvariantGlobalization>true</InvariantGlobalization>
+	  <OptimizationPreference>Size</OptimizationPreference>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
Modify the CSharp implementation to use AOT compilation on .NET 8 (rc1).