### PR TITLE
FSharp Reuse top5 array

### DIFF
--- a/fsharp/Program.fs
+++ b/fsharp/Program.fs
@@ -1,8 +1,6 @@
 ﻿open System
 open System.IO
-open System.Runtime.Intrinsics
 open FSharp.NativeInterop
-// open FSharp.Json
 open System.Collections.Generic
 open System.Text.Json
 


### PR DESCRIPTION
- Reuse the top5 array
- Reduce the size of taggedPostCount array using bytes since the number of tags is <=100

This gave me a small speed boost on my machine from ~20ms to ~17ms
I'm running an Intel 13900K