### PR TITLE
C# optimizations

### DIFF
--- a/csharp/Program.cs
+++ b/csharp/Program.cs
@@ -96,7 +96,7 @@ Console.WriteLine("Processing time (w/o IO): {0}ms", sw.Elapsed.TotalMillisecond
 
 File.WriteAllText(@"../related_posts_csharp.json", JsonSerializer.Serialize(allRelatedPosts, MyJsonContext.Default.RelatedPostsArray));
 
-public struct Post
+public class Post
 {
     [JsonPropertyName("_id")]
     public string Id { get; set; }
@@ -108,7 +108,7 @@ public struct Post
     public string[] Tags { get; set; }
 }
 
-public struct RelatedPosts
+public class RelatedPosts
 {
     [JsonPropertyName("_id")]
     public string Id { get; set; }

--- a/csharp/Program.cs
+++ b/csharp/Program.cs
@@ -9,17 +9,25 @@ var posts = JsonSerializer.Deserialize<List<Post>>(File.ReadAllText(@"../posts.j
 
 var sw = Stopwatch.StartNew();
 
-var tagMap = new Dictionary<string, List<int>>();
+// slower when int[] is used
+var tagMapTemp = new Dictionary<string, Stack<int>>();
 
 for (var i = 0; i < posts!.Count; i++)
 {
     foreach (var tag in posts[i].Tags)
     {
         // single lookup
-        ref var tagMapList = ref CollectionsMarshal.GetValueRefOrAddDefault(tagMap, tag, out _);
-        tagMapList ??= new List<int>();
-        tagMapList.Add(i);
+        ref var tagMapStack = ref CollectionsMarshal.GetValueRefOrAddDefault(tagMapTemp, tag, out _);
+        tagMapStack ??= new Stack<int>();
+        tagMapStack.Push(i);
     }
+}
+
+var tagMap = new Dictionary<string, int[]>();
+
+foreach (var (tag, postIds) in tagMapTemp)
+{
+    tagMap[tag] = postIds.ToArray();
 }
 
 var allRelatedPosts = new RelatedPosts[posts.Count];

--- a/csharp/Program.cs
+++ b/csharp/Program.cs
@@ -17,9 +17,9 @@ for (var i = 0; i < posts!.Count; i++)
     foreach (var tag in posts[i].Tags)
     {
         // single lookup
-        ref var tagMapStack = ref CollectionsMarshal.GetValueRefOrAddDefault(tagMapTemp, tag, out _);
-        tagMapStack ??= new Stack<int>();
-        tagMapStack.Push(i);
+        ref var stack = ref CollectionsMarshal.GetValueRefOrAddDefault(tagMapTemp, tag, out _);
+        stack ??= new Stack<int>();
+        stack.Push(i);
     }
 }
 

--- a/csharp/related.csproj
+++ b/csharp/related.csproj
@@ -5,6 +5,7 @@
     <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <PublishAot>true</PublishAot>
   </PropertyGroup>
 
 </Project>

--- a/run.ps1
+++ b/run.ps1
@@ -82,7 +82,7 @@ function run_csharp {
     Write-Output "Running CSharp"
     Set-Location ./csharp
     dotnet restore
-    dotnet publish -c release
+    dotnet publish -c release --self-contained -o "bin/release/net7.0/publish"
     if ($HYPER -eq 1) {
         hyperfine -r 5 -w 2 --show-output "./bin/release/net7.0/publish/related$EXT"
     }

--- a/run.sh
+++ b/run.sh
@@ -375,7 +375,7 @@ run_csharp() {
     echo "Running CSharp" &&
         cd ./csharp &&
         dotnet restore &&
-        dotnet publish -c release &&
+        dotnet publish -c release --self-contained -o "bin/release/net7.0/publish" &&
         if [ $HYPER == 1 ]; then
             capture "C#" hyperfine -r 5 -w 2 --show-output "./bin/release/net7.0/publish/related"
         else


### PR DESCRIPTION
- AOT compilation.
- ~tagMap initialization without copying collections again.~ Surprisingly, pushing to stack and then converting to array is faster than using List<int>
- Reduced dictionary lookups in the loop to single lookup.
- Removed required keyword (AOT JSON serialization doesn't build in .NET 7 with `required` keyword, this might be fixed in .NET 8). 
- changed structs to classes as structs are copy by value by default (improves performance in this case)