### PR TITLE
Removing unnecessary allocation (Julia)

### DIFF
--- a/julia/related.jl
+++ b/julia/related.jl
@@ -2,6 +2,7 @@ using JSON3
 using StructTypes
 using Dates
 using StaticArrays
+using DataStructures
 
 function relatedIO()
     json_string = read("../posts.json", String)
@@ -71,8 +72,8 @@ function related(posts)
     relatedposts = Vector{RelatedPost}(undef, length(posts))
     taggedpostcount = Vector{Int64}(undef, length(posts))
 
-    maxn = zeros(Int, topn)
-    maxv = ones(Int, topn)
+    maxn = Vector{Int64}(undef, topn)
+    maxv = Vector{Int64}(undef, topn)
 
     for (i, post) in enumerate(posts)
         taggedpostcount .= 0
@@ -86,7 +87,7 @@ function related(posts)
 
         fastmaxindex!(taggedpostcount, topn, maxn, maxv)
 
-        relatedpost = RelatedPost(post._id, post.tags, SVector{topn}([posts[ix] for ix in maxn]))
+        relatedpost = RelatedPost(post._id, post.tags, SVector{topn}(posts[ix] for ix in maxn))
         relatedposts[i] = relatedpost
     end
 

--- a/julia/related.jl
+++ b/julia/related.jl
@@ -2,7 +2,6 @@ using JSON3
 using StructTypes
 using Dates
 using StaticArrays
-using DataStructures
 
 function relatedIO()
     json_string = read("../posts.json", String)


### PR DESCRIPTION
Just removing the vector allocation from `SVector{topn}([posts[ix] for ix in maxn)])`. 

It defeats the purpose of using the `SVector` altogether.

Maybe this results in ~1ms gain - but it is more about the logic this round.