### PR TITLE
String -> Symbol for tags

### DIFF
--- a/julia/related.jl
+++ b/julia/related.jl
@@ -25,12 +25,12 @@ end
 struct PostData
     _id::String
     title::String
-    tags::Vector{String}
+    tags::Vector{Symbol}
 end
 
 struct RelatedPost
     _id::String
-    tags::Vector{String}
+    tags::Vector{Symbol}
     related::SVector{5,PostData}
 end
 
@@ -59,7 +59,7 @@ end
 
 function related(posts)
     topn = 5
-    tagmap = Dict{String,Vector{UInt16}}()
+    tagmap = Dict{Symbol,Vector{UInt16}}()
     for (idx, post) in enumerate(posts)
         for tag in post.tags
             if !haskey(tagmap, tag)


### PR DESCRIPTION
Since we can use the information that we have a maximum of 100 tags, Julia seems to behave better if (in the context) we store the tags as `Symbol` (instead of `String`).

I noticed that it reduces the variability of the runs and also gained about 1-2 ms on average on my machine.