### PR TITLE
FSharp Unroll loop

### DIFF
--- a/fsharp/Program.fs
+++ b/fsharp/Program.fs
@@ -59,8 +59,19 @@ let allRelatedPosts: RelatedPosts[] =
         let taggedPostCount = stackalloc posts.Length
 
         for tagId in post.tags do
-            for relatedPostId in tagPosts[tagId] do
-                taggedPostCount[relatedPostId] <- taggedPostCount[relatedPostId] + 1uy
+            let relatedPostIds = tagPosts[tagId]
+            let mutable i = 0
+
+            while i + 3 < relatedPostIds.Length do
+                taggedPostCount[i  ] <- taggedPostCount[i  ] + 1uy
+                taggedPostCount[i+1] <- taggedPostCount[i+1] + 1uy
+                taggedPostCount[i+2] <- taggedPostCount[i+2] + 1uy
+                taggedPostCount[i+3] <- taggedPostCount[i+3] + 1uy
+                i <- i + 4
+
+            while i < relatedPostIds.Length do
+                taggedPostCount[i] <- taggedPostCount[i] + 1uy
+                i <- i + 1
 
         taggedPostCount[postId] <- 0uy // ignore self
 


### PR DESCRIPTION
- Unroll the loop for totaling tag count overlaps.
- I observed ~15% speed up