### PR TITLE
use python 3.11 on runner

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -92,6 +92,11 @@ jobs:
               run: |
                 sudo apt install luajit lua5.1 luarocks lua-socket:amd64
 
+            - name: Install Python
+              uses: actions/setup-python@v4.7.1
+              with:
+                python-version: '3.11'
+
             - name: Run Benchmark
               run: ./run.sh all raw_results.md
 

--- a/python/related.py
+++ b/python/related.py
@@ -5,13 +5,14 @@ TOPN = 5
 lap()
 from collections import defaultdict
 
-import ujson as json
+import orjson
 
 
 def main():
     lap()
-    with open("../posts.json") as f:
-        posts = json.load(f)
+    with open("../posts.json", "rb") as f:
+        s = f.read()
+        posts = orjson.loads(s)
     lap()
 
     tag_map = defaultdict(list)
@@ -62,8 +63,9 @@ def main():
         }
 
     lap()
-    with open("../related_posts_python.json", "w") as f:
-        json.dump(all_related_posts, f)
+    with open("../related_posts_python.json", "wb") as f:
+        s = orjson.dumps(all_related_posts)
+        f.write(s)
     lap()
     finish()
 

--- a/python/related_np.py
+++ b/python/related_np.py
@@ -1,15 +1,16 @@
 from timing import lap, finish
 
 lap()
-import ujson as json
+import orjson
 import numpy as np
 from scipy.sparse import coo_array
 
 
 def main():
     lap()
-    with open("../posts.json") as f:
-        posts = json.load(f)
+    with open("../posts.json", "rb") as f:
+        s = f.read()
+        posts = orjson.loads(s)
     lap()
 
     unique_tags = set(tag for post in posts for tag in post["tags"])
@@ -48,8 +49,9 @@ def main():
         )
 
     lap()
-    with open("../related_posts_python_np.json", "w") as f:
-        json.dump(all_related, f)
+    with open("../related_posts_python_np.json", "wb") as f:
+        s = orjson.dumps(all_related)
+        f.write(s)
     lap()
     finish()
 

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,3 +1,3 @@
 numpy
 scipy
-ujson
+orjson

--- a/python/timing.py
+++ b/python/timing.py
@@ -20,4 +20,8 @@ def finish():
     else:
         end = perf[-2]  # before final output
         start = perf[-3]  # before process and output
-        print(f"Processing time (w/o IO): {(end - start)/1e9:.3f}s")
+        dt = (end - start)/1e9
+        if dt > 1:
+            print(f"Processing time (w/o IO): {(end - start) / 1e9:.3f}s")
+        else:
+            print(f"Processing time (w/o IO): {(end - start)/1e6:.1f}ms")

--- a/run.ps1
+++ b/run.ps1
@@ -33,7 +33,7 @@ function run_python {
         python3 -m venv venv
     }
     venv\Scripts\activate
-    if (!(pip freeze | Select-String -Pattern "ujson")) {
+    if (!(pip freeze | Select-String -Pattern "orjson")) {
         pip install -r requirements.txt
     }
     if ($HYPER -eq 1) {

--- a/run.sh
+++ b/run.sh
@@ -111,7 +111,7 @@ run_python() {
             python3 -m venv venv
         fi
     source venv/bin/activate &&
-        pip freeze | grep ujson || pip install -r requirements.txt &&
+        pip freeze | grep orjson || pip install -r requirements.txt &&
         if [ $HYPER == 1 ]; then
             capture "Python" hyperfine -r 5 --show-output "python3 ./related.py"
         else
@@ -129,7 +129,7 @@ run_python_np() {
             python3 -m venv venv
         fi
     source venv/bin/activate &&
-        (pip freeze | grep scipy && pip freeze | grep ujson) || pip install -r requirements.txt &&
+        (pip freeze | grep scipy && pip freeze | grep orjson) || pip install -r requirements.txt &&
         if [ $HYPER == 1 ]; then
             capture "Numpy" hyperfine -r 5 --show-output "python3 ./related_np.py"
         else

--- a/run.sh
+++ b/run.sh
@@ -129,7 +129,7 @@ run_python_np() {
             python3 -m venv venv
         fi
     source venv/bin/activate &&
-        (pip freeze | grep numpy && pip freeze | grep scipy && pip freeze | grep ujson) || pip install -r requirements.txt &&
+        (pip freeze | grep scipy && pip freeze | grep ujson) || pip install -r requirements.txt &&
         if [ $HYPER == 1 ]; then
             capture "Numpy" hyperfine -r 5 --show-output "python3 ./related_np.py"
         else


### PR DESCRIPTION
why 3.11:
- much better python solution performance:
    * from 3.4s https://github.com/fizmat/related_post_gen/actions/runs/6434908946/job/17475091343#step:23:34
    * to 1.7s https://github.com/fizmat/related_post_gen/actions/runs/6435418827/job/17476643206#step:24:39
    * on 3.10 the flat list approach(1e179d136d12f926048ccc24baf1ffd9deccc5ff) is barely an improvement (about 80ms, did not test on runner, tested on a local Linux machine)
- orjson has a weird effect in 3.10:
    * on 3.10 for some reason orjson slows down python (not numpy) processing by the same 80ms (also did not test on runner, tested on a local Linux machine)
    * on 3.11 orjson does not affect processing time

orjson also saves about 15ms on output (not very relevant with python, a little relevant with scipy, pretty relevant with numba)

