### PR TITLE
Numba (Python JIT compiler, a little cheating)

### DIFF
--- a/python/related_numba.py
+++ b/python/related_numba.py
@@ -32,6 +32,16 @@ def get_top5(relation_count):
     return max_i
 
 
+@njit
+def get_all_top5(n_posts, t_to_pp, p_to_tt):
+    all_top5 = np.empty((n_posts, 5), np.uint16)
+    for p in range(n_posts):
+        relation_count = count_relations(n_posts, t_to_pp, p_to_tt, p)
+        top5 = get_top5(relation_count)
+        all_top5[p] = top5
+    return all_top5
+
+
 def precompile():
     lap()
     # JIT compile by running with the arguments of the correct type
@@ -43,6 +53,11 @@ def precompile():
         typed.List([np.empty(0, dtype=np.uint8)]),
         0)
     get_top5(np.empty(0, dtype=np.uint8))
+    get_all_top5(
+        0,
+        typed.List([np.empty(0, dtype=np.uint16)]),
+        typed.List([np.empty(0, dtype=np.uint8)])
+    )
 
 
 def main():
@@ -63,10 +78,10 @@ def main():
     t_to_pp = typed.List(np.array(tp, dtype=np.uint16) for tp in t_to_pp)
     p_to_tt = typed.List(np.array(tp, dtype=np.uint8) for tp in p_to_tt)
 
+    all_top5 = get_all_top5(len(posts), t_to_pp, p_to_tt)
+
     all_related_posts = []
-    for p, post in enumerate(posts):
-        relation_count = count_relations(len(posts), t_to_pp, p_to_tt, p)
-        top5 = get_top5(relation_count)
+    for post, top5 in zip(posts, all_top5):
         all_related_posts.append(
             {
                 "_id": post["_id"],

--- a/python/related_numba.py
+++ b/python/related_numba.py
@@ -50,14 +50,16 @@ def main():
     unique_tags = set(tag for post in posts for tag in post["tags"])
     tag_to_t = {t: np.uint8(i) for i, t in enumerate(unique_tags)}
     t_to_pp = [[] for _ in unique_tags]
+    p_to_tt = []
     for p, post in enumerate(posts):
         for tag in post["tags"]:
             t_to_pp[tag_to_t[tag]].append(p)
+        p_to_tt.append(np.array([tag_to_t[tag] for tag in post["tags"]], dtype=np.uint8))
     t_to_pp = typed.List(np.array(tp, dtype=np.uint16) for tp in t_to_pp)
 
     all_related_posts = []
     for p, post in enumerate(posts):
-        tt = np.array([tag_to_t[tag] for tag in post["tags"]], dtype=np.uint8)
+        tt = p_to_tt[p]
         relation_count = count_relations(len(posts), t_to_pp, tt, p)
         top5 = get_top5(relation_count)
         all_related_posts.append(

--- a/python/related_numba.py
+++ b/python/related_numba.py
@@ -3,13 +3,13 @@ from timing import lap, finish
 lap()
 import numpy as np
 import orjson
-from numba import njit, typed
+from numba import njit, prange, typed
 
 
 @njit
 def get_all_top5(n_posts, t_to_pp, p_to_tt, p_to_nt):
     all_top5 = np.empty((n_posts, 5), np.uint16)
-    for current_p in range(n_posts):
+    for current_p in prange(n_posts):
         tt = p_to_tt[current_p]
         relation_count = np.zeros(n_posts, dtype=np.uint8)
         for tj in range(p_to_nt[current_p]):

--- a/python/related_numba.py
+++ b/python/related_numba.py
@@ -7,38 +7,29 @@ from numba import njit, typed
 
 
 @njit
-def count_relations(n_posts, t_to_pp, p_to_tt, p_to_nt, current_p):
-    tt = p_to_tt[current_p]
-    relation_count = np.zeros(n_posts, dtype=np.uint8)
-    for tj in range(p_to_nt[current_p]):
-        for p in t_to_pp[tt[tj]]:
-            relation_count[p] += 1
-    relation_count[current_p] = 0
-    return relation_count
-
-
-@njit
-def get_top5(relation_count):
-    max_i = np.zeros(5, dtype=np.uint16)
-    max_r = np.zeros(5, dtype=np.uint8)
-    for i, r in enumerate(relation_count):
-        for j in range(4, -1, -1):
-            if r > max_r[j]:
-                max_r[:j] = max_r[1:j + 1]
-                max_i[:j] = max_i[1:j + 1]
-                max_r[j] = r
-                max_i[j] = i
-                break
-    return max_i
-
-
-@njit
 def get_all_top5(n_posts, t_to_pp, p_to_tt, p_to_nt):
     all_top5 = np.empty((n_posts, 5), np.uint16)
-    for p in range(n_posts):
-        relation_count = count_relations(n_posts, t_to_pp, p_to_tt, p_to_nt, p)
-        top5 = get_top5(relation_count)
-        all_top5[p] = top5
+    for current_p in range(n_posts):
+        tt = p_to_tt[current_p]
+        relation_count = np.zeros(n_posts, dtype=np.uint8)
+        for tj in range(p_to_nt[current_p]):
+            for p in t_to_pp[tt[tj]]:
+                relation_count[p] += 1
+        relation_count[current_p] = 0
+
+        # get top 5:
+        # (probably can be optimized more)
+        max_i = np.zeros(5, dtype=np.uint16)
+        max_r = np.zeros(5, dtype=np.uint8)
+        for i, r in enumerate(relation_count):
+            for j in range(4, -1, -1):
+                if r > max_r[j]:
+                    max_r[:j] = max_r[1:j + 1]
+                    max_i[:j] = max_i[1:j + 1]
+                    max_r[j] = r
+                    max_i[j] = i
+                    break
+        all_top5[current_p] = max_i
     return all_top5
 
 
@@ -47,13 +38,6 @@ def precompile():
     # JIT compile by running with the arguments of the correct type
     # 1) measure compile time
     # 2) get correct processing (without compilation) time using the cached machine code
-    count_relations(
-        1,
-        typed.List([np.empty(0, dtype=np.uint16)]),
-        np.empty((1, 0), dtype=np.uint8),
-        np.zeros(1, dtype=np.uint8),
-        0)
-    get_top5(np.empty(0, dtype=np.uint8))
     get_all_top5(
         0,
         typed.List([np.empty(0, dtype=np.uint16)]),

--- a/python/related_numba.py
+++ b/python/related_numba.py
@@ -1,0 +1,51 @@
+from timing import lap, finish
+
+lap()
+import numpy as np
+import orjson
+
+def precompile():
+    lap()
+
+def main():
+    lap()
+    with open("../posts.json", "rb") as f:
+        s = f.read()
+        posts = orjson.loads(s)
+    lap()
+
+    unique_tags = set(tag for post in posts for tag in post["tags"])
+    tag_to_t = {t: np.uint8(i) for i, t in enumerate(unique_tags)}
+    t_to_pp = [[] for _ in unique_tags]
+    for p, post in enumerate(posts):
+        for tag in post["tags"]:
+            t_to_pp[tag_to_t[tag]].append(p)
+    t_to_pp = np.array([np.array(tp, dtype=np.uint16) for tp in t_to_pp], dtype=object)
+
+    all_related_posts = []
+    for p, post in enumerate(posts):
+        tt = np.array([tag_to_t[tag] for tag in post["tags"]], dtype=np.uint8)
+        relation_count = np.zeros(len(posts), dtype=np.uint8)
+        related_idx = np.concatenate(t_to_pp[tt])
+        np.add.at(relation_count, related_idx, 1)
+        relation_count[p] = 0
+        top5 = np.flip(np.argsort(relation_count, kind="stable")[-5:])
+        all_related_posts.append(
+            {
+                "_id": post["_id"],
+                "tags": post["tags"],
+                "related": [posts[i] for i in top5],
+            }
+        )
+
+    lap()
+    with open("../related_posts_python_numba.json", "wb") as f:
+        s = orjson.dumps(all_related_posts)
+        f.write(s)
+    lap()
+    finish()
+
+
+if __name__ == "__main__":
+    precompile()
+    main()

--- a/python/related_numba_con.py
+++ b/python/related_numba_con.py
@@ -1,0 +1,90 @@
+from timing import lap, finish
+
+lap()
+import numpy as np
+import orjson
+from numba import njit, typed
+
+
+@njit
+def get_all_top5(n_posts, t_to_pp, p_to_tt, p_to_nt):
+    all_top5 = np.empty((n_posts, 5), np.uint16)
+    for current_p in range(n_posts):
+        tt = p_to_tt[current_p]
+        relation_count = np.zeros(n_posts, dtype=np.uint8)
+        for tj in range(p_to_nt[current_p]):
+            for p in t_to_pp[tt[tj]]:
+                relation_count[p] += 1
+        relation_count[current_p] = 0
+
+        # get top 5:
+        # (probably can be optimized more)
+        max_i = np.zeros(5, dtype=np.uint16)
+        max_r = np.zeros(5, dtype=np.uint8)
+        for i, r in enumerate(relation_count):
+            for j in range(4, -1, -1):
+                if r > max_r[j]:
+                    max_r[:j] = max_r[1:j + 1]
+                    max_i[:j] = max_i[1:j + 1]
+                    max_r[j] = r
+                    max_i[j] = i
+                    break
+        all_top5[current_p] = max_i
+    return all_top5
+
+
+def precompile():
+    lap()
+    # JIT compile by running with the arguments of the correct type
+    # 1) measure compile time
+    # 2) get correct processing (without compilation) time using the cached machine code
+    get_all_top5(
+        0,
+        typed.List([np.empty(0, dtype=np.uint16)]),
+        np.empty((0, 0), dtype=np.uint8),
+        np.empty(0, dtype=np.uint8),
+    )
+
+
+def main():
+    lap()
+    with open("../posts.json", "rb") as f:
+        s = f.read()
+        posts = orjson.loads(s)
+    lap()
+
+    unique_tags = set(tag for post in posts for tag in post["tags"])
+    tag_to_t = {t: np.uint8(i) for i, t in enumerate(unique_tags)}
+    t_to_pp = [[] for _ in unique_tags]
+    p_to_nt = np.array([len(post["tags"]) for post in posts], dtype=np.uint8)
+    p_to_tt = np.empty((len(posts), p_to_nt.max()), dtype=np.uint8)
+
+    for p, post in enumerate(posts):
+        for tj, tag in enumerate(post["tags"]):
+            t_to_pp[tag_to_t[tag]].append(p)
+            p_to_tt[p, tj] = tag_to_t[tag]
+    t_to_pp = typed.List(np.array(tp, dtype=np.uint16) for tp in t_to_pp)
+
+    all_top5 = get_all_top5(len(posts), t_to_pp, p_to_tt, p_to_nt)
+
+    all_related_posts = []
+    for post, top5 in zip(posts, all_top5):
+        all_related_posts.append(
+            {
+                "_id": post["_id"],
+                "tags": post["tags"],
+                "related": [posts[i] for i in top5],
+            }
+        )
+
+    lap()
+    with open("../related_posts_python_numba_con.json", "wb") as f:
+        s = orjson.dumps(all_related_posts)
+        f.write(s)
+    lap()
+    finish()
+
+
+if __name__ == "__main__":
+    precompile()
+    main()

--- a/python/related_numba_con.py
+++ b/python/related_numba_con.py
@@ -3,13 +3,13 @@ from timing import lap, finish
 lap()
 import numpy as np
 import orjson
-from numba import njit, typed
+from numba import njit, prange, typed
 
 
-@njit
+@njit(parallel=True)
 def get_all_top5(n_posts, t_to_pp, p_to_tt, p_to_nt):
     all_top5 = np.empty((n_posts, 5), np.uint16)
-    for current_p in range(n_posts):
+    for current_p in prange(n_posts):
         tt = p_to_tt[current_p]
         relation_count = np.zeros(n_posts, dtype=np.uint8)
         for tj in range(p_to_nt[current_p]):

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,3 +1,4 @@
 numpy
 scipy
 orjson
+numba

--- a/run.sh
+++ b/run.sh
@@ -140,6 +140,24 @@ run_python_np() {
 
 }
 
+run_python_numba() {
+    echo "Running Numba" &&
+        cd ./python &&
+        if [ ! -d "venv" ]; then
+            python3 -m venv venv
+        fi
+    source venv/bin/activate &&
+        (pip freeze | grep numpy && pip freeze | grep orjson) || pip install -r requirements.txt &&
+        if [ $HYPER == 1 ]; then
+            capture "Numba" hyperfine -r 10 -w 3 --show-output "python3 ./related_numba.py"
+        else
+            command time -f '%es %Mk' python3 ./related_numba.py
+        fi
+    deactivate &&
+        check_output "related_posts_python_numba.json"
+
+}
+
 run_crystal() {
     echo "Running Crystal" &&
         cd ./crystal &&
@@ -460,6 +478,10 @@ elif [ "$first_arg" = "numpy" ]; then
 
     run_python_np
 
+elif [ "$first_arg" = "numba" ]; then
+
+    run_python_numba
+
 elif [ "$first_arg" = "cr" ]; then
 
     run_crystal
@@ -553,6 +575,7 @@ elif [ "$first_arg" = "all" ]; then
         run_rust_con || echo -e "\n" &&
         run_python || echo -e "\n" &&
         run_python_np || echo -e "\n" &&
+        run_python_numba || echo -e "\n" &&
         run_crystal || echo -e "\n" &&
         run_zig || echo -e "\n" &&
         run_julia || echo -e "\n" &&
@@ -600,6 +623,6 @@ elif [ "$first_arg" = "clean" ]; then
 
 else
 
-    echo "Valid args: go | go_con | rust | rust_con | py | numpy | cr | zig | odin | jq | julia | v | dart | swift | swift_con | node | bun | deno | java | java_graal | nim | luajit | lua | all | clean. Unknown argument: $first_arg"
+    echo "Valid args: go | go_con | rust | rust_con | py | numpy | numba | cr | zig | odin | jq | julia | v | dart | swift | swift_con | node | bun | deno | java | java_graal | nim | luajit | lua | all | clean. Unknown argument: $first_arg"
 
 fi

--- a/run.sh
+++ b/run.sh
@@ -147,7 +147,7 @@ run_python_numba() {
             python3 -m venv venv
         fi
     source venv/bin/activate &&
-        (pip freeze | grep numpy && pip freeze | grep orjson) || pip install -r requirements.txt &&
+        (pip freeze | grep numba && pip freeze | grep orjson) || pip install -r requirements.txt &&
         if [ $HYPER == 1 ]; then
             capture "Numba" hyperfine -r 10 -w 3 --show-output "python3 ./related_numba.py"
         else

--- a/run.sh
+++ b/run.sh
@@ -158,6 +158,24 @@ run_python_numba() {
 
 }
 
+run_python_numba_con() {
+    echo "Running Numba Concurrent" &&
+        cd ./python &&
+        if [ ! -d "venv" ]; then
+            python3 -m venv venv
+        fi
+    source venv/bin/activate &&
+        (pip freeze | grep numba && pip freeze | grep orjson) || pip install -r requirements.txt &&
+        if [ $HYPER == 1 ]; then
+            capture "Numba Concurrent" hyperfine -r 10 -w 3 --show-output "python3 ./related_numba_con.py"
+        else
+            command time -f '%es %Mk' python3 ./related_numba_con.py
+        fi
+    deactivate &&
+        check_output "related_posts_python_numba_con.json"
+
+}
+
 run_crystal() {
     echo "Running Crystal" &&
         cd ./crystal &&
@@ -482,6 +500,10 @@ elif [ "$first_arg" = "numba" ]; then
 
     run_python_numba
 
+elif [ "$first_arg" = "numba_con" ]; then
+
+    run_python_numba_con
+
 elif [ "$first_arg" = "cr" ]; then
 
     run_crystal
@@ -623,6 +645,6 @@ elif [ "$first_arg" = "clean" ]; then
 
 else
 
-    echo "Valid args: go | go_con | rust | rust_con | py | numpy | numba | cr | zig | odin | jq | julia | v | dart | swift | swift_con | node | bun | deno | java | java_graal | nim | luajit | lua | all | clean. Unknown argument: $first_arg"
+    echo "Valid args: go | go_con | rust | rust_con | py | numpy | numba | numba_con | cr | zig | odin | jq | julia | v | dart | swift | swift_con | node | bun | deno | java | java_graal | nim | luajit | lua | all | clean. Unknown argument: $first_arg"
 
 fi


### PR DESCRIPTION
- a numpy solution not based on matrix multiplication, but adding arrays in a loop. Slower than the matrix solution, on par with the original Python solution: 1.5s processing, 1.5s total
- JIT compile the inner loop function with Numba: instantly overtake even scipy solution on processing: 140 ms processing, 650ms total (because of 180ms import and 310ms JIT compile)
- sorting to find top5 takes almost half the processing time. replace sorting with one pass over the array to save 55ms (*this part probably can be optimized*).
- other minor optimizations. Final: 60ms processing, 1.2s total (mostly compile)
- parallelize the outer loop: 27ms processing, 1.6s total (even longer compile)

Should the parallelized solution be a separate entry in run.sh?

It's not hard to use just one python script for both sequential and parallelized solution, but probably simpler and more consistent with the other solutions to have a different .py file for the parallel version.

Performance measurments: https://github.com/fizmat/related_post_gen_python_timing/blob/main/main.ipynb