### PR TITLE
Elide bounds check

### DIFF
--- a/fsharp/Program.fs
+++ b/fsharp/Program.fs
@@ -60,7 +60,8 @@ let allRelatedPosts: RelatedPosts[] =
 
         for tagId in post.tags do
             for relatedPostId in tagPosts[tagId] do
-                taggedPostCount[relatedPostId] <- taggedPostCount[relatedPostId] + 1uy
+                let mutable relatedPostTagCount = &taggedPostCount[relatedPostId]
+                relatedPostTagCount <- relatedPostTagCount + 1uy
 
         taggedPostCount[postId] <- 0uy // ignore self
 


### PR DESCRIPTION
- Profiling shows loop for counting related post counts is ~45% of the time
- Logic elides a bounds check in the hottest loop by returning a value by ref
- ~5% performance improvement on my machine
- Note, this is making the bounds check unnecessary, so it's not violating the rule that says you can't drop bounds checks