### PR TITLE
go: reduce GC using a soft memory limit

### DIFF
--- a/go/main_test.go
+++ b/go/main_test.go
@@ -1,0 +1,15 @@
+package main
+
+import "testing"
+
+// TestMain is useful for tracing a single run:
+// go test -trace go.trace && go tool trace go.trace
+func TestMain(t *testing.T) {
+	main()
+}
+
+func BenchmarkMain(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		main()
+	}
+}

--- a/go_con/main_test.go
+++ b/go_con/main_test.go
@@ -1,0 +1,15 @@
+package main
+
+import "testing"
+
+// TestMain is useful for tracing a single run:
+// go test -trace go.trace && go tool trace go.trace
+func TestMain(t *testing.T) {
+	main()
+}
+
+func BenchmarkMain(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		main()
+	}
+}

--- a/run.sh
+++ b/run.sh
@@ -44,7 +44,7 @@ run_go() {
         cd ./go &&
         go build &&
         if [ $HYPER == 1 ]; then
-            capture "Go" hyperfine -r 10 -w 5 --show-output "./related"
+            capture "Go" hyperfine -r 10 -w 5 --show-output "GOGC=off GOMEMLIMIT=32MiB ./related"
         else
             command ${time} -f '%es %Mk' ./related
         fi
@@ -58,7 +58,7 @@ run_go_concurrent() {
         cd ./go_con &&
         go build &&
         if [ $HYPER == 1 ]; then
-            capture "Go Concurrent" hyperfine -r 10 -w 5 --show-output "./related_concurrent"
+            capture "Go Concurrent" hyperfine -r 10 -w 5 --show-output "GOGC=off GOMEMLIMIT=64MiB ./related_concurrent"
         else
             command ${time} -f '%es %Mk' ./related_concurrent
         fi

--- a/run.sh
+++ b/run.sh
@@ -42,7 +42,7 @@ capture() {
 run_go() {
     echo "Running Go" &&
         cd ./go &&
-        GOEXPERIMENT=arenas go build &&
+        go build &&
         if [ $HYPER == 1 ]; then
             capture "Go" hyperfine -r 10 -w 5 --show-output "./related"
         else
@@ -56,7 +56,7 @@ run_go() {
 run_go_concurrent() {
     echo "Running Go Concurrent" &&
         cd ./go_con &&
-        GOEXPERIMENT=arenas go build &&
+        go build &&
         if [ $HYPER == 1 ]; then
             capture "Go Concurrent" hyperfine -r 10 -w 5 --show-output "./related_concurrent"
         else


### PR DESCRIPTION
This PR reduces the GC of the Go implementations by setting a soft memory limit that is high enough to avoid the GC kicking in. This speeds up the JSON decoding and encoding at the beginning and end. It doesn't speed up the processing loop in the middle.

Below are the results from my M1 MBP, YMMV.

## ./run.sh go

<table>
<tr>
	<td>
Before

<img width="1278" alt="CleanShot 2023-10-08 at 23 04 11@2x" src="https://github.com/jinyus/related_post_gen/assets/15000/878e762c-ba2e-4a79-80be-b3dd00d35d53">

```
  Time (mean ± σ):      39.7 ms ±   1.7 ms    [User: 33.9 ms, System: 11.2 ms]
  Range (min … max):    35.9 ms …  41.6 ms    10 runs
```
</td>
</tr>
<tr>
	<td>
After

<img width="1278" alt="CleanShot 2023-10-08 at 23 03 15@2x" src="https://github.com/jinyus/related_post_gen/assets/15000/26d61393-5014-4a7f-b9b1-d97c8c6b2ec9">

```
  Time (mean ± σ):      35.1 ms ±   0.6 ms    [User: 28.0 ms, System: 5.4 ms]
  Range (min … max):    33.8 ms …  36.2 ms    10 runs
```
</td>
</tr>
</table> 

## ./run.sh go_con

<table>
<tr>
	<td>
Before

<img width="1279" alt="CleanShot 2023-10-08 at 23 24 24@2x" src="https://github.com/jinyus/related_post_gen/assets/15000/9119b908-520c-443a-96d9-38eb30add394">

```
  Time (mean ± σ):      25.3 ms ±   1.9 ms    [User: 38.0 ms, System: 11.1 ms]
  Range (min … max):    22.9 ms …  28.0 ms    10 runs
```
</td>
</tr>
<tr>
	<td>
After

<img width="1279" alt="CleanShot 2023-10-08 at 23 28 39@2x" src="https://github.com/jinyus/related_post_gen/assets/15000/741d690f-7880-491a-b982-e856da4f6244">

```
  Time (mean ± σ):      20.9 ms ±   0.5 ms    [User: 31.9 ms, System: 7.4 ms]
  Range (min … max):    20.3 ms …  22.0 ms    10 runs
```
</td>
</tr>
</table> 

## more ideas

For amd64 I'm wondering if setting `GOAMD64=v4` during the build would squeeze out some extra performance. I didn't have time to try on an intel machine yet.

Another thing I did try was using PGO, but I wasn't able to see a noticeable difference.

Oh and one more thing I tried was different [bitmap](https://pkg.go.dev/github.com/kelindar/bitmap) indexes for the tags and posts in order to use SIMD operations. However, it's hard to beat the current algorithm for the current data distributions, all my attempts ended up being slower.