### PR TITLE
Simplify and optimize Julia implementation

### DIFF
--- a/julia/related.jl
+++ b/julia/related.jl
@@ -33,7 +33,7 @@ end
 
 StructTypes.StructType(::Type{PostData}) = StructTypes.Struct()
 
-function fastmaxindex!(xs::Vector{Int64}, topn, maxn, maxv)
+function fastmaxindex!(xs::Vector{UInt16}, topn, maxn, maxv)
     maxn .= 1
     maxv .= 0
     top = maxv[1]
@@ -60,21 +60,19 @@ function related(posts)
     topn = 5
     # key is every possible "tag" used in all posts
     # value is indicies of all "post"s that used this tag
-    tagmap = Dict{String,Vector{Int64}}()
+    tagmap = Dict{String,Vector{UInt16}}()
     for (idx, post) in enumerate(posts)
         for tag in post.tags
-            if !haskey(tagmap, tag)
-                tagmap[tag] = Vector{Int64}()
-            end
-            push!(tagmap[tag], idx)
+            tags = get!(() -> UInt16[], tagmap, tag)
+            push!(tags, idx)
         end
     end
 
     relatedposts = Vector{RelatedPost}(undef, length(posts))
-    taggedpostcount = Vector{Int64}(undef, length(posts))
+    taggedpostcount = Vector{UInt16}(undef, length(posts))
 
-    maxn = MVector{topn, Int64}(undef)
-    maxv = MVector{topn, Int64}(undef)
+    maxn = MVector{topn, UInt16}(undef)
+    maxv = MVector{topn, UInt16}(undef)
 
     for (i, post) in enumerate(posts)
         taggedpostcount .= 0
@@ -83,7 +81,7 @@ function related(posts)
         # give all related post +1 in `taggedpostcount` shadow vector
         for tag in post.tags
             for idx in tagmap[tag]
-                taggedpostcount[idx] += 1
+                taggedpostcount[idx] += one(UInt16)
             end
         end
 


### PR DESCRIPTION
Two changes:
- Replace `haskey`, `d[k] = x` and `d[k]` with `get!` to cut down on code size and the number of required hashes. `get!` is a builtin function designed specifically for this common use case of getting an element from a dictionary or instantiating it if it's missing.
- Use an appropriately sized integer type for post index and counts. This will cause bugs if there are more than 2^16 posts. If that possibility for error is "cheating", we can add a near-zero-cost dispatch to dynamically determine the appropriate number type. I'd estimate that that dispatch will add about 6 lines of code, increase compilation time a bit, and not affect runtime at all.