### PR TITLE
Bring back TreeDictionary

### DIFF
--- a/swift_con/Sources/main.swift
+++ b/swift_con/Sources/main.swift
@@ -1,4 +1,4 @@
-// import struct Collections.TreeDictionary
+import struct Collections.TreeDictionary
 import Foundation
 import Dispatch
 
@@ -33,7 +33,7 @@ func main() {
 
     let start = DispatchTime.now()
 
-    var tagMap =  [String: [Int]]()
+    var tagMap: TreeDictionary<String, [Int]> = [:]
 
     for (i, post) in posts.enumerated() {
         for tag in post.tags {


### PR DESCRIPTION
Not sure why this one got deleted. It's an official and stable library: https://github.com/apple/swift-collections, unlike what the rust_con is using with `rust_rayon v0.1.0`, which is now failing with `error[E0658]: use of unstable library feature 'local_key_cell_methods'` ;)