### PR TITLE
Revert "formatting Julia and remove unnecessary deps"

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -229,7 +229,7 @@ run_zig() {
 run_julia() {
     echo "Running Julia" &&
         cd ./julia &&
-        julia -e 'using Pkg; Pkg.add.(["JSON3", "StaticArrays"])' &&
+        julia -e 'using Pkg; Pkg.add.(["JSON3", "StructTypes", "StaticArrays"])' &&
         if [ $HYPER == 1 ]; then
             capture "Julia" hyperfine -r $runs -w $warmup --show-output "julia related.jl"
         else


### PR DESCRIPTION
it's possible my weird tweaking introduced performance degradation.

I don't fully understand Github CI environment, so let's revert it to be safe