### PR TITLE
[csharp] Changed Clear() to Fill(0)

### DIFF
--- a/csharp/Program.cs
+++ b/csharp/Program.cs
@@ -38,7 +38,7 @@ Span<(byte Count, int PostId)> top5 = stackalloc (byte Count, int PostId)[topN];
 
 for (var i = 0; i < postsCount; i++)
 {
-    taggedPostCount.Clear();  // reset counts
+    taggedPostCount.Fill(0);  // reset counts
 
     foreach (var tag in posts[i].Tags)
     {


### PR DESCRIPTION
Around 9% faster on my machine

```
dotnet publish -c Release
1..1000 | %{ measure-command { .\bin\release\net7.0\win-x64\native\related.exe } | % TotalMilliseconds } | measure -Average
```

- With `Fill(0)`: 79.4570753ms
- With `Clear()`: 86.0791141ms