### PR TITLE
Separate JIT and AOT configs for C#

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -89,6 +89,9 @@ jobs:
 
             - name: Install Dotnet
               uses: actions/setup-dotnet@v3
+              with:
+                dotnet-version: '8.0.x'
+                dotnet-quality: 'preview'
 
             - name: Install LuaJit
               run: |

--- a/csharp/related.csproj
+++ b/csharp/related.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <ServerGarbageCollection>true</ServerGarbageCollection>

--- a/csharp/related.csproj
+++ b/csharp/related.csproj
@@ -5,7 +5,6 @@
     <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <PublishAot>true</PublishAot>
     <ServerGarbageCollection>true</ServerGarbageCollection>
   </PropertyGroup>
 

--- a/run.sh
+++ b/run.sh
@@ -456,11 +456,11 @@ run_fsharp() {
 run_csharp() {
     echo "Running CSharp (JIT)" &&
         cd ./csharp &&
-        dotnet publish -c release --self-contained -o "bin/release/net7.0/jit" &&
+        dotnet publish -c release --self-contained -o "bin/release/net8.0/jit" &&
         if [ $HYPER == 1 ]; then
-            capture "C# (JIT)" hyperfine -r $runs -w $warmup --show-output "./bin/release/net7.0/jit/related"
+            capture "C# (JIT)" hyperfine -r $runs -w $warmup --show-output "./bin/release/net8.0/jit/related"
         else
-            command ${time} -f '%es %Mk' ./bin/release/net7.0/jit/related
+            command ${time} -f '%es %Mk' ./bin/release/net8.0/jit/related
         fi
 
     check_output "related_posts_csharp.json"
@@ -469,11 +469,11 @@ run_csharp() {
 run_csharp_aot() {
     echo "Running CSharp (AOT)" &&
         cd ./csharp &&
-        dotnet publish -c release --self-contained -p PublishAot=true -o "bin/release/net7.0/aot" &&
+        dotnet publish -c release --self-contained -p PublishAot=true -o "bin/release/net8.0/aot" &&
         if [ $HYPER == 1 ]; then
-            capture "C# (AOT)" hyperfine -r $runs -w $warmup --show-output "./bin/release/net7.0/aot/related"
+            capture "C# (AOT)" hyperfine -r $runs -w $warmup --show-output "./bin/release/net8.0/aot/related"
         else
-            command ${time} -f '%es %Mk' ./bin/release/net7.0/aot/related
+            command ${time} -f '%es %Mk' ./bin/release/net8.0/aot/related
         fi
 
     check_output "related_posts_csharp.json"

--- a/run.sh
+++ b/run.sh
@@ -454,14 +454,26 @@ run_fsharp() {
 }
 
 run_csharp() {
-    echo "Running CSharp" &&
+    echo "Running CSharp (JIT)" &&
         cd ./csharp &&
-        dotnet restore &&
-        dotnet publish -c release --self-contained -o "bin/release/net7.0/publish" &&
+        dotnet publish -c release --self-contained -o "bin/release/net7.0/jit" &&
         if [ $HYPER == 1 ]; then
-            capture "C#" hyperfine -r $runs -w $warmup --show-output "./bin/release/net7.0/publish/related"
+            capture "C# (JIT)" hyperfine -r $runs -w $warmup --show-output "./bin/release/net7.0/jit/related"
         else
-            command ${time} -f '%es %Mk' ./bin/release/net7.0/publish/related
+            command ${time} -f '%es %Mk' ./bin/release/net7.0/jit/related
+        fi
+
+    check_output "related_posts_csharp.json"
+}
+
+run_csharp_aot() {
+    echo "Running CSharp (AOT)" &&
+        cd ./csharp &&
+        dotnet publish -c release --self-contained -p PublishAot=true -o "bin/release/net7.0/aot" &&
+        if [ $HYPER == 1 ]; then
+            capture "C# (AOT)" hyperfine -r $runs -w $warmup --show-output "./bin/release/net7.0/aot/related"
+        else
+            command ${time} -f '%es %Mk' ./bin/release/net7.0/aot/related
         fi
 
     check_output "related_posts_csharp.json"
@@ -671,6 +683,10 @@ elif [ "$first_arg" = "csharp" ]; then
 
     run_csharp
 
+elif [ "$first_arg" = "csharp_aot" ]; then
+
+    run_csharp_aot
+
 elif [ "$first_arg" = "fsharp_con" ]; then
 
     run_fsharp_con
@@ -723,6 +739,7 @@ elif [ "$first_arg" = "all" ]; then
         run_fsharp || echo -e "\n" &&
         run_fsharp_con || echo -e "\n" &&
         run_csharp || echo -e "\n" &&
+        run_csharp_aot || echo -e "\n" &&
         run_luajit || echo -e "\n" &&
         run_lua || echo -e "\n" &&
         run_ocaml || echo -e "\n" &&
@@ -755,6 +772,6 @@ elif [ "$first_arg" = "clean" ]; then
 
 else
 
-    echo "Valid args: go | go_con | rust | rust_con | d | py | numpy | numba | numba_con | cr | zig | odin | jq | julia | v | dart | swift | swift_con | node | bun | deno | java | java_graal | java_graal_con | nim | luajit | lua | all | clean. Unknown argument: $first_arg"
+    echo "Valid args: go | go_con | rust | rust_con | d | py | numpy | numba | numba_con | cr | zig | odin | jq | julia | v | dart | swift | swift_con | node | bun | deno | java | java_graal | java_graal_con | nim | luajit | lua | csharp | csharp_aot | all | clean. Unknown argument: $first_arg"
 
 fi


### PR DESCRIPTION
While AOT finishes faster for the 5k entries JSON in the repo, it is not faster for larger sets, at least in .NET 7. Benchmark both flavors like for Java or Dart.

Things look different in .NET 8 (I see .NET 8 AOT matching Go speed) but the repo didn't update to .NET 8 yet. It could - .NET 8 RC2 is supported for use in production by Microsoft (marked [go-live](https://dotnet.microsoft.com/en-us/download/dotnet/8.0)).