### PR TITLE
[Julia] Remove StaticArrays.jl, replace with Vector5 types

### DIFF
--- a/julia/Project.toml
+++ b/julia/Project.toml
@@ -1,0 +1,5 @@
+[deps]
+Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+StructTypes = "856f2bd8-1eba-4b0a-8007-ebc267875bd4"

--- a/julia/related.jl
+++ b/julia/related.jl
@@ -1,9 +1,12 @@
+using Pkg
+Pkg.instantiate()
 using JSON3
 using StructTypes
 using Dates
-using StaticArrays
 
 # warmup is done by hyperfine
+
+include("vector5.jl")
 
 function relatedIO()
     json_string = read("../posts.json", String)
@@ -30,7 +33,7 @@ end
 struct RelatedPost
     _id::String
     tags::Vector{String}
-    related::SVector{5,PostData}
+    related::SVector5{PostData}
 end
 
 StructTypes.StructType(::Type{PostData}) = StructTypes.Struct()
@@ -80,8 +83,8 @@ function related(::Type{T}, posts) where {T}
     relatedposts = Vector{RelatedPost}(undef, length(posts))
     taggedpostcount = Vector{T}(undef, length(posts))
 
-    maxn = Vector{T}(undef,topn)
-    maxv = Vector{T}(undef,topn)
+    maxn = MVector5{T}()
+    maxv = MVector5{T}()
 
     for (i, post) in enumerate(posts)
         taggedpostcount .= 0
@@ -99,7 +102,7 @@ function related(::Type{T}, posts) where {T}
 
         fastmaxindex!(taggedpostcount, topn, maxn, maxv)
 
-        relatedpost = RelatedPost(post._id, post.tags, SVector{topn}(@view posts[maxn]))
+        relatedpost = RelatedPost(post._id, post.tags, SVector5(@view posts[maxn]))
         relatedposts[i] = relatedpost
     end
 

--- a/julia/related.jl
+++ b/julia/related.jl
@@ -1,5 +1,3 @@
-using Pkg
-Pkg.instantiate()
 using JSON3
 using StructTypes
 using Dates

--- a/julia/vector5.jl
+++ b/julia/vector5.jl
@@ -1,0 +1,38 @@
+abstract type Vector5{T} <: AbstractVector{T} end
+Base.size(::Vector5) = (5,)
+Base.IndexStyle(::Type{<: Vector5}) = IndexLinear()
+Base.getindex(A::Vector5, i::Int) = 
+    i == 1 ? A.a :
+    i == 2 ? A.b :
+    i == 3 ? A.c :
+    i == 4 ? A.d :
+    i == 5 ? A.e :
+    throw(BoundsError(A, i))
+
+mutable struct MVector5{T} <: Vector5{T}
+    a::T
+    b::T
+    c::T
+    d::T
+    e::T
+end
+MVector5{T}() where T = MVector5{T}(zero(T), zero(T), zero(T), zero(T), zero(T))
+Base.setindex!(A::MVector5, v, i::Int) =
+    i == 1 ? A.a = v :
+    i == 2 ? A.b = v :
+    i == 3 ? A.c = v :
+    i == 4 ? A.d = v :
+    i == 5 ? A.e = v :
+    throw(BoundsError(A, i))
+
+struct SVector5{T} <: Vector5{T}
+    a::T
+    b::T
+    c::T
+    d::T
+    e::T
+end
+SVector5{T}(nt::NTuple{5,T}) where T  =
+    SVector5{T}(nt...)
+SVector5(av::AbstractVector{T}) where T  =
+    SVector5{T}(av...)

--- a/julia_con/Project.toml
+++ b/julia_con/Project.toml
@@ -1,0 +1,6 @@
+[deps]
+ChunkSplitters = "ae650224-84b6-46f8-82ea-d812ca08434e"
+Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+StructTypes = "856f2bd8-1eba-4b0a-8007-ebc267875bd4"

--- a/julia_con/related.jl
+++ b/julia_con/related.jl
@@ -1,6 +1,3 @@
-using Pkg
-Pkg.instantiate()
-
 using Base.Threads
 
 using JSON3

--- a/julia_con/related.jl
+++ b/julia_con/related.jl
@@ -84,8 +84,8 @@ function related(::Type{T}, posts) where {T}
 
     @threads for (postsrange, _) in chunks(posts, nthreads())
         topn = 5
-        maxn = Vector{T}(undef,topn)
-        maxv = Vector{T}(undef,topn)
+        maxn = MVector5{T}()
+        maxv = MVector5{T}()
         taggedpostcount = Vector{T}(undef, length(posts))
 
         for i in postsrange

--- a/julia_con/related.jl
+++ b/julia_con/related.jl
@@ -1,12 +1,16 @@
+using Pkg
+Pkg.instantiate()
+
 using Base.Threads
 
 using JSON3
 using StructTypes
 using Dates
-using StaticArrays
 using ChunkSplitters
 
 # warmup is done by hyperfine
+
+include("../julia/vector5.jl")
 
 function relatedIO()
     json_string = read("../posts.json", String)
@@ -33,7 +37,7 @@ end
 struct RelatedPost
     _id::String
     tags::Vector{String}
-    related::SVector{5,PostData}
+    related::SVector5{PostData}
 end
 
 StructTypes.StructType(::Type{PostData}) = StructTypes.Struct()
@@ -105,7 +109,7 @@ function related(::Type{T}, posts) where {T}
 
             fastmaxindex!(taggedpostcount, topn, maxn, maxv)
 
-            relatedpost = RelatedPost(post._id, post.tags, SVector{topn}(@view posts[maxn]))
+            relatedpost = RelatedPost(post._id, post.tags, SVector5(@view posts[maxn]))
             relatedposts[i] = relatedpost
         end
     end

--- a/run.sh
+++ b/run.sh
@@ -229,6 +229,7 @@ run_zig() {
 run_julia() {
     echo "Running Julia" &&
         cd ./julia &&
+        julia --project -e "using Pkg; Pkg.instantiate()" &&
         if [ $HYPER == 1 ]; then
             capture "Julia" hyperfine -r $runs -w $warmup --show-output "julia --project related.jl"
         else
@@ -241,6 +242,7 @@ run_julia() {
 run_julia_con() {
     echo "Running Julia Concurrent" &&
         cd ./julia_con &&
+        julia --project -e "using Pkg; Pkg.instantiate()" &&
         if [ $HYPER == 1 ]; then
             capture "Julia Concurrent" hyperfine -r $runs -w $warmup --show-output "julia --project --threads auto related.jl"
         else

--- a/run.sh
+++ b/run.sh
@@ -229,11 +229,10 @@ run_zig() {
 run_julia() {
     echo "Running Julia" &&
         cd ./julia &&
-        julia -e 'using Pkg; Pkg.add.(["JSON3", "StructTypes", "StaticArrays"])' &&
         if [ $HYPER == 1 ]; then
-            capture "Julia" hyperfine -r $runs -w $warmup --show-output "julia related.jl"
+            capture "Julia" hyperfine -r $runs -w $warmup --show-output "julia --project related.jl"
         else
-            command ${time} -f '%es %Mk' julia related.jl
+            command ${time} -f '%es %Mk' julia --project related.jl
         fi
 
     check_output "related_posts_julia.json"
@@ -242,11 +241,10 @@ run_julia() {
 run_julia_con() {
     echo "Running Julia Concurrent" &&
         cd ./julia_con &&
-        julia -e 'using Pkg; Pkg.add.(["JSON3", "StructTypes", "StaticArrays", "ChunkSplitters"])' &&
         if [ $HYPER == 1 ]; then
-            capture "Julia Concurrent" hyperfine -r $runs -w $warmup --show-output "julia --threads auto related.jl"
+            capture "Julia Concurrent" hyperfine -r $runs -w $warmup --show-output "julia --project --threads auto related.jl"
         else
-            command ${time} -f '%es %Mk' julia --threads auto related.jl
+            command ${time} -f '%es %Mk' julia --project --threads auto related.jl
         fi
 
     check_output "related_posts_julia_con.json"


### PR DESCRIPTION
This entirely removes StaticArrays.jl from the Julia code. Instead, we implement new {M,S}Vector5 types specialized for mutable or immutable 5-element collections.

Also, this replaces manual package management with Project.toml files including the package UUIDs, adding specificity and additional security.

Fixes #194
