### PR TITLE
[Nim] nimble flags

### DIFF
--- a/nim/.gitignore
+++ b/nim/.gitignore
@@ -1,4 +1,4 @@
 build/
 nimcache/
 related
-default.profraw
+default.prof*

--- a/nim/related.nimble
+++ b/nim/related.nimble
@@ -23,6 +23,8 @@ task buildopt, "build optimized":
     echo "Gen stat ", i, "/", STAT_STEPS
     exec "./related > /dev/null"
     mvFile "default.profraw", "default.profraw." & $i
-  exec "llvm-profdata merge default.profraw.* --output default.profdata"
+  when defined(macosx):
+    exec "xcrun llvm-profdata merge default.profraw.* --output default.profdata"
+  else:
+    exec "llvm-profdata merge default.profraw.* --output default.profdata"
   exec "nimble -d:profileUse -d:release build"
-

--- a/run.sh
+++ b/run.sh
@@ -491,7 +491,7 @@ run_nim() {
 run_nim_con() {
     echo "Running Nim Concurrent" &&
         cd ./nim_con &&
-        echo "using ${nproc} threads" &&
+        echo "using $((2 * ${nproc})) threads" &&
         if [ -z "$appendToFile" ]; then # only build on 5k run
             nimble install -y &&
                 ./buildopt.sh ${nproc}

--- a/run.sh
+++ b/run.sh
@@ -476,7 +476,7 @@ run_nim() {
     echo "Running Nim" &&
         cd ./nim &&
         if [ -z "$appendToFile" ]; then # only build on 5k run
-            nimble install -y &&
+            nimble -y install -d &&
                 nimble buildopt
         fi &&
         if [ $HYPER == 1 ]; then
@@ -493,7 +493,7 @@ run_nim_con() {
         cd ./nim_con &&
         echo "using $((2 * ${nproc})) threads" &&
         if [ -z "$appendToFile" ]; then # only build on 5k run
-            nimble install -y &&
+            nimble -y install -d &&
                 ./buildopt.sh ${nproc}
         fi &&
         if [ $HYPER == 1 ]; then


### PR DESCRIPTION
Fixes #300 

On any machine where the environment isn't from scratch and builds/runs were being done without `-d`, after the changes in this PR it's recommended to do the following before the next build/run
```
$ rm -rf "${HOME}"/.nimble/pkgs2/related*
```
If using a custom `NIMBLE_DIR`, it would be:
```
$ rm -rf "${NIMBLE_DIR}"/pkgs2/related*
```

I made a few other small changes in this PR, each in their own commit.