### PR TITLE
[Nim] adapt approaches in nim_con to to single-threaded impl and improve perf in both

### DIFF
--- a/nim/.gitignore
+++ b/nim/.gitignore
@@ -1,4 +1,3 @@
-build/
+default.prof*
 nimcache/
 related
-default.prof*

--- a/nim/config.nims
+++ b/nim/config.nims
@@ -1,6 +1,4 @@
-switch("opt", "speed")
 switch("cc", "clang")
-switch("panics", "off")
 switch("passC", "-flto")
 switch("passL", "-flto")
 
@@ -13,4 +11,3 @@ when defined(profileUse):
   echo "Build with profileUse"
   switch("passC", "-fprofile-instr-use")
   switch("passL", "-fprofile-instr-use")
-

--- a/nim/config.nims
+++ b/nim/config.nims
@@ -1,6 +1,7 @@
 switch("cc", "clang")
 switch("passC", "-flto")
 switch("passL", "-flto")
+switch("threads", "off")
 
 when defined(profileGen):
   echo "Build with profileGen"

--- a/nim/config.nims
+++ b/nim/config.nims
@@ -7,6 +7,7 @@ const
     (if defined(release): "release" else: "debug"), projectName())
 
 switch("cc", "clang")
+switch("mm", "arc")
 switch("nimcache", cacheSubdir)
 switch("passC", "-flto")
 switch("passL", "-flto")

--- a/nim/config.nims
+++ b/nim/config.nims
@@ -1,4 +1,13 @@
+import std/os
+
+const
+  cfgPath = currentSourcePath.parentDir
+  cacheSubdirHead = joinPath(cfgPath, "nimcache")
+  cacheSubdir = joinPath(cacheSubdirHead,
+    (if defined(release): "release" else: "debug"), projectName())
+
 switch("cc", "clang")
+switch("nimcache", cacheSubdir)
 switch("passC", "-flto")
 switch("passL", "-flto")
 when not defined(profileGen):

--- a/nim/config.nims
+++ b/nim/config.nims
@@ -1,6 +1,8 @@
 switch("cc", "clang")
 switch("passC", "-flto")
 switch("passL", "-flto")
+when not defined(profileGen):
+  switch("passL", "-s")
 switch("threads", "off")
 
 when defined(profileGen):

--- a/nim/related.nimble
+++ b/nim/related.nimble
@@ -2,7 +2,7 @@
 
 version       = "0.1.0"
 author        = "jinyus"
-description   = "A new awesome nimble package"
+description   = "Nim implementation for related_post_gen"
 license       = "MIT"
 srcDir        = "src"
 bin           = @["related"]
@@ -11,7 +11,7 @@ bin           = @["related"]
 # Dependencies
 
 requires "nim >= 2.0.0"
-requires "jsony"
+requires "jsony#head"
 requires "xxhash"
 
 const STAT_STEPS = 10

--- a/nim/related.nimble
+++ b/nim/related.nimble
@@ -14,17 +14,13 @@ requires "nim >= 2.0.0"
 requires "jsony#head"
 requires "xxhash"
 
-const STAT_STEPS = 10
-
 task buildopt, "build optimized":
-  exec "rm -f default.profdata default.profraw.*"
+  exec "rm -f default.prof*"
   exec "nimble -d:profileGen -d:release build"
-  for i in 1..STAT_STEPS:
-    echo "Gen stat ", i, "/", STAT_STEPS
-    exec "./related > /dev/null"
-    mvFile "default.profraw", "default.profraw." & $i
+  echo "Gen stat"
+  exec "./related > /dev/null"
   when defined(macosx):
-    exec "xcrun llvm-profdata merge default.profraw.* --output default.profdata"
+    exec "xcrun llvm-profdata merge default.profraw --output default.profdata"
   else:
-    exec "llvm-profdata merge default.profraw.* --output default.profdata"
-  exec "nimble -d:profileUse -d:release build"
+    exec "llvm-profdata merge default.profraw --output default.profdata"
+  exec "nimble --verbose -d:profileUse -d:release build"

--- a/nim/related.nimble
+++ b/nim/related.nimble
@@ -13,14 +13,3 @@ bin           = @["related"]
 requires "nim >= 2.0.0"
 requires "jsony#head"
 requires "xxhash"
-
-task buildopt, "build optimized":
-  exec "rm -f default.prof*"
-  exec "nimble -d:profileGen -d:release build"
-  echo "Gen stat"
-  exec "./related > /dev/null"
-  when defined(macosx):
-    exec "xcrun llvm-profdata merge default.profraw --output default.profdata"
-  else:
-    exec "llvm-profdata merge default.profraw --output default.profdata"
-  exec "nimble --verbose -d:profileUse -d:release build"

--- a/nim/src/related.nim
+++ b/nim/src/related.nim
@@ -1,83 +1,88 @@
-import std/[hashes, monotimes, times]
-import jsony
-import xxhash
-import fixedtable
+import std/[hashes, monotimes, sequtils, sugar, times]
+import pkg/[jsony, xxhash]
+import ./fixedtable
 
 type
-  Post = ref object
+  Post = object
     `"_id"`: string
     title: string
     tags : seq[string]
 
+  Posts = seq[ref Post]
+
   RelatedPosts = object
     `"_id"`: string
     tags : seq[string]
-    related : seq[Post]
+    related : Posts
+
+  Top5 = array[5, tuple[idx: int, count: uint8]]
 
 const
-    input = "../posts.json"
-    output = "../related_posts_nim.json"
+  input = "../posts.json"
+  output = "../related_posts_nim.json"
 
 func hash(x: string): Hash =
   cast[Hash](XXH3_64bits(x))
 
-func findTop5(posts: seq[Post], taggedPostCount: seq[uint8]): seq[Post] =
-  result = newSeq[Post](5)
-  var top5: array[5, tuple[idx: int, count: uint8]]
+proc findTop5(taggedPostCount: seq[uint8], top5: var Top5) =
   for i, count in taggedPostCount:
     if count > top5[4].count:
       top5[4] = (idx: i, count: count)
       for pos in countdown(3, 0):
         if count > top5[pos].count:
           swap(top5[pos+1], top5[pos])
-  for i, t in top5:
-    result[i] = posts[t.idx]
 
-func genTagMap(posts: seq[Post]): Table[string, seq[int]] =
+func genTagMap(posts: Posts): Table[string, seq[int]] =
   result = initTable[string, seq[int]](100)
   for i, post in posts:
     for tag in post.tags:
       result.withValue(tag, val):
-        val[].add i
+        val[].add(i)
       do:
         result[tag] = @[i]
 
-func countTaggedPost(taggedPostCount: var seq[uint8], i: int, post: Post, tagMap: Table[string, seq[int]]) =
+proc countTaggedPost(
+    taggedPostCount: var seq[uint8],
+    post: ref Post,
+    idx: int,
+    tagMap: Table[string, seq[int]]) =
   for tag in post.tags:
-    for otherIDX in tagMap[tag]:
-      inc(taggedPostCount[otherIDX])
-  taggedPostCount[i] = 0 # remove self
+    for relIdx in tagMap[tag]:
+      inc taggedPostCount[relIdx]
+  taggedPostCount[idx] = 0 # remove self
 
-proc process(posts: seq[Post]): seq[RelatedPosts] =
-  let start = getMonotime()
+proc process(
+    posts: Posts,
+    tagMap: Table[string, seq[int]],
+    top5s: var seq[Top5]) =
+  for i, post in posts:
+    var taggedPostCount = newSeq[uint8](posts.len)
+    taggedPostCount.countTaggedPost(post, i, tagMap)
+    taggedPostCount.findTop5(top5s[i])
 
-  let tagMap = genTagMap(posts)
+proc readPosts(path: string): Posts =
+  path.readFile.fromJson(Posts)
 
-  var allRelatedPosts = newSeq[RelatedPosts](posts.len)
-  var taggedPostCount = newSeq[uint8](posts.len)
-
-  for i, post in posts.pairs:
-    zeroMem(taggedPostCount[0].addr, posts.len)
-    taggedPostCount.countTaggedPost(i, post, tagMap)
-
-    let relatedPosts = RelatedPosts(
-      `"_id"`: post.`"_id"`,
-      tags: post.tags,
-      related: posts.findTop5(taggedPostCount)
-      )
-
-    allRelatedPosts[i] = relatedPosts
-
-  let total = getMonotime() - start
-
-  echo "Processing time (w/o IO): ", total.inMicroseconds / 1000, "ms"
-
-  return allRelatedPosts
+func resolve(posts: Posts, top5s: seq[Top5]): seq[RelatedPosts] =
+  collect(newSeqOfCap(posts.len)):
+    for i, top5 in top5s:
+      RelatedPosts(
+        `"_id"`: posts[i].`"_id"`,
+        tags: posts[i].tags,
+        related: top5.mapIt(posts[it.idx]))
 
 proc main() =
-  let posts = readFile(input).fromJson(seq[Post])
-  let res = process(posts)
-  writeFile(output, res.toJson)
+  let
+    posts = input.readPosts
+    start = getMonotime()
+    tagMap = posts.genTagMap
+  var top5s = newSeq[Top5](posts.len)
+  posts.process(tagMap, top5s)
+  let
+    relatedPosts = posts.resolve(top5s)
+    total = getMonotime() - start
+  echo "Processing time (w/o IO): ", total.inMicroseconds / 1000, "ms"
+  output.writeFile(relatedPosts.toJson)
 
 when isMainModule:
   main()

--- a/nim_con/buildopt.sh
+++ b/nim_con/buildopt.sh
@@ -27,24 +27,7 @@ else
     build_kind=release
 fi
 
-echo "Compiling profiled executable"
 nim c -d:FixedChanSize=${chansize} \
       -d:ThreadPoolSize=${threads} \
-      -d:profileGen \
-      -d:${build_kind} \
-      related_con.nim
-
-echo "Generating profile"
-./build/related_con >/dev/null
-if [[ "$(uname)" = "Darwin" ]]; then
-    xcrun llvm-profdata merge -output="${profdata}" "${profraw}"
-else
-    llvm-profdata merge -output="${profdata}" "${profraw}"
-fi
-
-echo "Compiling optimized executable"
-nim c -d:FixedChanSize=${chansize} \
-      -d:ThreadPoolSize=${threads} \
-      -d:profileUse \
       -d:${build_kind} \
       related_con.nim

--- a/nim_con/buildopt.sh
+++ b/nim_con/buildopt.sh
@@ -9,7 +9,7 @@ fi
 ## hardwired
 # nproc=4
 
-threads=$((2 * ${nproc}))
+threads=$((1 * ${nproc}))
 
 chansize=${2}
 if [[ -z "${chansize}" ]]; then

--- a/nim_con/config.nims
+++ b/nim_con/config.nims
@@ -10,9 +10,8 @@ switch("nimcache", cacheSubdir)
 
 --cc:clang
 --outdir:build
---threads:on
---tlsEmulation:off
---warning:"Effect:off"
+--tlsEmulation:off # default on|off varies by platform
+--warning:"Effect:off" # suppress noisy compiler warnings re: malebolgia
 
 when defined(profileGen):
   --hints:off

--- a/nim_con/config.nims
+++ b/nim_con/config.nims
@@ -9,6 +9,7 @@ const
 switch("nimcache", cacheSubdir)
 
 --cc:clang
+--mm:arc
 --outdir:build
 --tlsEmulation:off # default on|off varies by platform
 --warning:"Effect:off" # suppress noisy compiler warnings re: malebolgia

--- a/run.sh
+++ b/run.sh
@@ -473,7 +473,7 @@ run_nim() {
         cd ./nim &&
         if [ -z "$appendToFile" ]; then # only build on 5k run
             nimble -y install -d &&
-                nimble buildopt
+                nimble --verbose build -d:release
         fi &&
         if [ $HYPER == 1 ]; then
             capture "Nim" hyperfine -r $runs -w $warmup --show-output "./related"

--- a/run.sh
+++ b/run.sh
@@ -487,7 +487,7 @@ run_nim() {
 run_nim_con() {
     echo "Running Nim Concurrent" &&
         cd ./nim_con &&
-        echo "using $((2 * ${nproc})) threads" &&
+        echo "using ${nproc} threads" &&
         if [ -z "$appendToFile" ]; then # only build on 5k run
             nimble -y install -d &&
                 ./buildopt.sh ${nproc}


### PR DESCRIPTION
As I mentioned in #300, I'm trying things out on a free tier Azure VM with the same specs as your benchmarking VM.

With changes in this PR, I'm seeing some speedups
```
Nim Concurrent:

        Benchmark 1: ./build/related_con
        Processing time (w/o IO): 23.264ms
        Processing time (w/o IO): 22.754ms
        Processing time (w/o IO): 22.866ms
        Processing time (w/o IO): 22.699ms
        Processing time (w/o IO): 22.644ms
        Processing time (w/o IO): 22.95ms
        Processing time (w/o IO): 22.575ms
        Processing time (w/o IO): 22.785ms
        Processing time (w/o IO): 22.73ms
        Processing time (w/o IO): 22.623ms
        Processing time (w/o IO): 22.603ms
        Processing time (w/o IO): 22.645ms
        Processing time (w/o IO): 22.583ms
          Time (mean ± σ):      45.2 ms ±   0.8 ms    [User: 77.1 ms, System: 7.0 ms]
          Range (min … max):    43.8 ms …  46.6 ms    10 runs
         
Nim Concurrent:

        Benchmark 1: ./build/related_con
        Processing time (w/o IO): 309.609ms
        Processing time (w/o IO): 313.802ms
        Processing time (w/o IO): 314.481ms
          Time (mean ± σ):     411.4 ms ±   6.8 ms    [User: 955.1 ms, System: 42.3 ms]
          Range (min … max):   406.6 ms … 416.3 ms    2 runs
         
Nim Concurrent:

        Benchmark 1: ./build/related_con
        Processing time (w/o IO): 3214.735ms
        Processing time (w/o IO): 2883.433ms
        Processing time (w/o IO): 2883.317ms
          Time (mean ± σ):      3.164 s ±  0.001 s    [User: 8.772 s, System: 0.078 s]
          Range (min … max):    3.164 s …  3.165 s    2 runs
          
Nim:

        Benchmark 1: ./related
        Processing time (w/o IO): 27.721ms
        Processing time (w/o IO): 27.495ms
        Processing time (w/o IO): 27.446ms
        Processing time (w/o IO): 27.396ms
        Processing time (w/o IO): 27.313ms
        Processing time (w/o IO): 27.65ms
        Processing time (w/o IO): 27.512ms
        Processing time (w/o IO): 27.363ms
        Processing time (w/o IO): 27.346ms
        Processing time (w/o IO): 27.336ms
        Processing time (w/o IO): 27.423ms
        Processing time (w/o IO): 27.309ms
        Processing time (w/o IO): 27.504ms
          Time (mean ± σ):      49.6 ms ±   0.5 ms    [User: 40.1 ms, System: 9.5 ms]
          Range (min … max):    49.1 ms …  50.9 ms    10 runs
         
Nim:

        Benchmark 1: ./related
        Processing time (w/o IO): 379.217ms
        Processing time (w/o IO): 380.812ms
        Processing time (w/o IO): 379.355ms
          Time (mean ± σ):     467.8 ms ±   0.2 ms    [User: 435.8 ms, System: 31.9 ms]
          Range (min … max):   467.6 ms … 468.0 ms    2 runs
         
Nim:

        Benchmark 1: ./related
        Processing time (w/o IO): 3400.621ms
        Processing time (w/o IO): 3398.67ms
        Processing time (w/o IO): 3399.28ms
          Time (mean ± σ):      3.680 s ±  0.002 s    [User: 3.599 s, System: 0.076 s]
          Range (min … max):    3.678 s …  3.681 s    2 runs
```
There seems to be a lot of runtime variability in the VM, probably because the box it's running on is more/less busy at various times.

So I'm not confident you'll get improved numbers, i.e. it might flip around again with `nim_con` being slower than `nim`, but let's see how it goes.

I've tried to explain clearly the why/what in each  commit message. I didn't completely overhaul the structure and code of `nim`, just adapted some of what I did in `nim_con` where it seemed like it should speedup the single-threaded impl.

I have some ideas about switching to a different task manager library for `nim_con`. There are several promising options besides `malebolgia` and they each take different approaches. Maybe one of those approaches will be better suited to the Azure VM environment, will be interesting to see how it goes.