### PR TITLE
[Go] Trigger GC Manually

### DIFF
--- a/go/main.go
+++ b/go/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"time"
+	"runtime"
 )
 
 const topN = 5
@@ -37,6 +38,9 @@ func main() {
 	if err != nil {
 		fmt.Println(err)
 	}
+
+	runtime.GC()
+
 	start := time.Now()
 
 	postsLen := len(posts)

--- a/go_con/main.go
+++ b/go_con/main.go
@@ -56,6 +56,8 @@ func main() {
 		log.Panicln(err)
 	}
 
+	runtime.GC()
+
 	start := time.Now()
 
 	postsLength := len(posts)


### PR DESCRIPTION
Main:
```
Go	| 24.25 ms | 374.70 ms | 3.28 s	

Go Concurrent | 13.31 ms | 166.98 ms | 1.42 s
```

This PR:
```
Go:                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                               
        Benchmark 1: ./related                                                                                                                                                                                                                 
        Processing time (w/o IO): 24.189115ms                                                                                                                                                                                                  
        Processing time (w/o IO): 24.275116ms                                                                                                                                                                                                  
        Processing time (w/o IO): 24.408217ms                                                                                                                                                                                                  
        Processing time (w/o IO): 24.311517ms                                                                                                                                                                                                  
        Processing time (w/o IO): 24.298016ms                                                                                                                                                                                                  
        Processing time (w/o IO): 24.174015ms                                                                                                                                                                                                  
        Processing time (w/o IO): 24.145314ms                                                                                                                                                                                                  
        Processing time (w/o IO): 24.494018ms                                                                                                                                                                                                  
        Processing time (w/o IO): 24.364317ms                                                                                                                                                                                                  
        Processing time (w/o IO): 24.328117ms                                                                                                                                                                                                  
        Processing time (w/o IO): 24.303516ms                                                                                                                                                                                                  
        Processing time (w/o IO): 24.180315ms                                                                                                                                                                                                  
        Processing time (w/o IO): 24.343417ms                                                                                                                                                                                                  
          Time (mean ± σ):      63.8 ms ±   0.9 ms    [User: 58.5 ms, System: 12.1 ms]                                                                                                                                                         
          Range (min … max):    62.4 ms …  65.2 ms    10 runs                                                                                                                                                                                  
                                                                                                                                                                                                                                               
Go:                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                               
        Benchmark 1: ./related                                                                                                                                                                                                                 
        Processing time (w/o IO): 371.024328ms                                                                                                                                                                                                 
        Processing time (w/o IO): 371.560437ms                                                                                                                                                                                                 
        Processing time (w/o IO): 372.409848ms                                                                                                                                                                                                 
          Time (mean ± σ):     516.0 ms ±   1.2 ms    [User: 506.7 ms, System: 30.8 ms]                                                                                                                                                        
          Range (min … max):   515.1 ms … 516.8 ms    2 runs                                                                                                                                                                                   
                                                                                                                                                                                                                                               
Go:                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                               
        Benchmark 1: ./related                                                                                                                                                                                                                 
        Processing time (w/o IO): 3.274102262s                                                                                                                                                                                                 
        Processing time (w/o IO): 3.275032902s                                                                                                                                                                                                 
        Processing time (w/o IO): 3.270145345s                                                                                                                                                                                                 
          Time (mean ± σ):      3.764 s ±  0.024 s    [User: 3.783 s, System: 0.102 s]                                                                                                                                                         
          Range (min … max):    3.747 s …  3.781 s    2 runs                                                                                                                                                                                   
                                                                      

Go Concurrent:

        Benchmark 1: ./related_concurrent
        Processing time (w/o IO): 11.790838ms
        Processing time (w/o IO): 12.539346ms
        Processing time (w/o IO): 11.737937ms
        Processing time (w/o IO): 11.683836ms
        Processing time (w/o IO): 11.736237ms
        Processing time (w/o IO): 11.800438ms
        Processing time (w/o IO): 11.772537ms
        Processing time (w/o IO): 11.574235ms
        Processing time (w/o IO): 11.767837ms
        Processing time (w/o IO): 11.636936ms
        Processing time (w/o IO): 11.507534ms
        Processing time (w/o IO): 11.933039ms
        Processing time (w/o IO): 11.854638ms
          Time (mean ± σ):      50.7 ms ±   1.7 ms    [User: 77.5 ms, System: 11.6 ms]
          Range (min … max):    48.4 ms …  53.1 ms    10 runs
         
Go Concurrent:

        Benchmark 1: ./related_concurrent
        Processing time (w/o IO): 163.400307ms
        Processing time (w/o IO): 165.464531ms
        Processing time (w/o IO): 163.947813ms
          Time (mean ± σ):     306.0 ms ±   1.6 ms    [User: 782.0 ms, System: 31.5 ms]
          Range (min … max):   304.9 ms … 307.2 ms    2 runs
         
Go Concurrent:

        Benchmark 1: ./related_concurrent
        Processing time (w/o IO): 1.415887702s
        Processing time (w/o IO): 1.430433179s
        Processing time (w/o IO): 1.42805695s
          Time (mean ± σ):      1.902 s ±  0.004 s    [User: 6.132 s, System: 0.114 s]
          Range (min … max):    1.899 s …  1.904 s    2 runs

```