### PR TITLE
[Nim Con] improve performance

### DIFF
--- a/nim_con/buildopt.sh
+++ b/nim_con/buildopt.sh
@@ -27,24 +27,7 @@ else
     build_kind=release
 fi
 
-echo "Compiling profiled executable"
 nim c -d:FixedChanSize=${chansize} \
       -d:ThreadPoolSize=${threads} \
-      -d:profileGen \
-      -d:${build_kind} \
-      related_con.nim
-
-echo "Generating profile"
-./build/related_con >/dev/null
-if [[ "$(uname)" = "Darwin" ]]; then
-    xcrun llvm-profdata merge -output="${profdata}" "${profraw}"
-else
-    llvm-profdata merge -output="${profdata}" "${profraw}"
-fi
-
-echo "Compiling optimized executable"
-nim c -d:FixedChanSize=${chansize} \
-      -d:ThreadPoolSize=${threads} \
-      -d:profileUse \
       -d:${build_kind} \
       related_con.nim

--- a/nim_con/buildopt.sh
+++ b/nim_con/buildopt.sh
@@ -9,7 +9,7 @@ fi
 ## hardwired
 # nproc=4
 
-threads=$((2 * ${nproc}))
+threads=$((1 * ${nproc}))
 
 chansize=${2}
 if [[ -z "${chansize}" ]]; then

--- a/nim_con/config.nims
+++ b/nim_con/config.nims
@@ -10,9 +10,8 @@ switch("nimcache", cacheSubdir)
 
 --cc:clang
 --outdir:build
---threads:on
---tlsEmulation:off
---warning:"Effect:off"
+--tlsEmulation:off # default on|off varies by platform
+--warning:"Effect:off" # suppress noisy compiler warnings re: malebolgia
 
 when defined(profileGen):
   --hints:off

--- a/nim_con/config.nims
+++ b/nim_con/config.nims
@@ -9,6 +9,7 @@ const
 switch("nimcache", cacheSubdir)
 
 --cc:clang
+--mm:arc
 --outdir:build
 --tlsEmulation:off # default on|off varies by platform
 --warning:"Effect:off" # suppress noisy compiler warnings re: malebolgia

--- a/run.sh
+++ b/run.sh
@@ -487,7 +487,7 @@ run_nim() {
 run_nim_con() {
     echo "Running Nim Concurrent" &&
         cd ./nim_con &&
-        echo "using $((2 * ${nproc})) threads" &&
+        echo "using ${nproc} threads" &&
         if [ -z "$appendToFile" ]; then # only build on 5k run
             nimble -y install -d &&
                 ./buildopt.sh ${nproc}


### PR DESCRIPTION
Here's a PR with ***only*** the `[Nim Con]` commits, i.e. affecting `nim_con` only, in case there's a hangup about the changes in `nim/` on `main` vs. `nim_rev` branches.

Will post fresh numbers from my Azure VM below. For `nim_con`, `nim_rev` consistently outperforms `main`, especially big differences for 20k and 60k runs.
