### PR TITLE
Limit allocations in concurrent C# impl

### DIFF
--- a/csharp_con/Program.cs
+++ b/csharp_con/Program.cs
@@ -56,9 +56,10 @@ static RelatedPosts[] GetRelatedPosts(List<Post> posts)
 
     static RelatedPosts GetRelatedPosts(int i, FrozenDictionary<string, int[]> tagMap, List<Post> posts)
     {
-        Span<byte> taggedPostCount =
-            new byte[((posts.Count + Vector<byte>.Count - 1) / Vector<byte>.Count) * Vector<byte>.Count];
+        Span<byte> taggedPostCount = t_taggedPostCount ??
+            (t_taggedPostCount = new byte[((posts.Count + Vector<byte>.Count - 1) / Vector<byte>.Count) * Vector<byte>.Count]);
         Span<Vector<byte>> taggedPostVector = MemoryMarshal.Cast<byte, Vector<byte>>(taggedPostCount);
+        taggedPostCount.Fill(0);
 
         // Iterate over all of the tags for the current post.
         foreach (var tag in posts[i].Tags)
@@ -131,6 +132,11 @@ static RelatedPosts[] GetRelatedPosts(List<Post> posts)
     return allRelatedPosts;
 }
 
+partial class Program
+{
+    [ThreadStatic]
+    static byte[] t_taggedPostCount;
+}
 
 public record struct Post
 {


### PR DESCRIPTION
We were allocating 3.5 GB of arrays. I'm seeing an 8% improvement, but it should ideally be measured on the benchmark machine because I wouldn't be too surprised if the OS was able to give out fresh zero initialized pages faster than we can zero them manually -  and this is not _too many_ individual allocations to garbage collect.