### PR TITLE
[Nim Con] PGO with gcc, profiled on 60k posts

### DIFF
--- a/nim_con/.gitignore
+++ b/nim_con/.gitignore
@@ -1,3 +1,3 @@
 build/
-default.prof*
+default*.prof*
 nimcache/

--- a/nim_con/build.sh
+++ b/nim_con/build.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+nproc=${1}
+if [[ -z "${nproc}" ]]; then
+    nproc=4
+fi
+## hardwired
+# nproc=4
+
+threads=$((1 * ${nproc}))
+
+chansize=${2}
+if [[ -z "${chansize}" ]]; then
+    chansize=$((2 * ${threads}))
+fi
+## hardwired
+# chansize=16
+
+if [[ ${DANGER} = true ]]; then
+    build_kind=danger
+else
+    build_kind=release
+fi
+
+rm -rf nimcache
+
+nim c -d:FixedChanSize=${chansize} \
+      -d:ThreadPoolSize=${threads} \
+      -d:${build_kind} \
+      related_con.nim

--- a/nim_con/buildopt.sh
+++ b/nim_con/buildopt.sh
@@ -33,7 +33,14 @@ nim c -d:FixedChanSize=${chansize} \
       related_con.nim
 
 echo "Generating profile"
+cd ..
+cp posts.json posts_orig.json
+python gen_fake_posts.py 60000
+cd nim_con
 ./build/related_con >/dev/null
+cd ..
+mv posts_orig.json posts.json
+cd nim_con
 if [[ "$(cc --version 2>/dev/null | head -1)" = *"clang"* ]]; then
     if [[ -n "$(which xcrun 2>/dev/null)" ]]; then
         xcrun llvm-profdata merge default*.profraw --output default.profdata

--- a/nim_con/config.nims
+++ b/nim_con/config.nims
@@ -8,7 +8,6 @@ const
 
 switch("nimcache", cacheSubdir)
 
---cc:clang
 --mm:arc
 --outdir:build
 --tlsEmulation:off # default on|off varies by platform
@@ -16,12 +15,12 @@ switch("nimcache", cacheSubdir)
 
 when defined(profileGen):
   --hints:off
-  --passC:"-fprofile-instr-generate"
-  --passL:"-fprofile-instr-generate"
+  --passC:"-fprofile-generate"
+  --passL:"-fprofile-generate"
 
 when defined(profileUse):
-  --passC:"-fprofile-instr-use"
-  --passL:"-fprofile-instr-use"
+  --passC:"-fprofile-use"
+  --passL:"-fprofile-use"
 
 when defined(release):
   --passC:"-flto"

--- a/nim_con/config.nims
+++ b/nim_con/config.nims
@@ -23,8 +23,8 @@ when defined(profileUse):
   --passL:"-fprofile-use"
 
 when defined(release):
-  --passC:"-flto"
-  --passL:"-flto"
+  --passC:"-flto=auto"
+  --passL:"-flto=auto"
   when not defined(profileGen):
     --passL:"-s"
 else:


### PR DESCRIPTION
Changes are for `nim_con` only.

`nim_rev_7` == `nim_con` with gcc PGO 60k
```
Run Benchmark (5k posts)
Running Nim Concurrent
using 4 threads
Nim Concurrent:

	Benchmark 1: ./build/related_con
	Processing time (w/o IO): 19.161ms
	Processing time (w/o IO): 22.642ms
	Processing time (w/o IO): 19.441ms
	Processing time (w/o IO): 19.226ms
	Processing time (w/o IO): 19.127ms
	Processing time (w/o IO): 19.519ms
	Processing time (w/o IO): 20.306ms
	Processing time (w/o IO): 19.881ms
	Processing time (w/o IO): 19.356ms
	Processing time (w/o IO): 18.953ms
	Processing time (w/o IO): 19.148ms
	Processing time (w/o IO): 18.922ms
	Processing time (w/o IO): 19.931ms
	 Time (mean ± σ):      49.7 ms ±   1.0 ms    [User: 62.8 ms, System: 15.8 ms]
	 Range (min … max):    48.5 ms …  51.6 ms    10 runs
	
Checking output
Success: related_posts_nim_con.json is valid!

Generate 20000 posts
Run Benchmark (15k posts)
Running Nim Concurrent
using 4 threads
Nim Concurrent:

	Benchmark 1: ./build/related_con
	Processing time (w/o IO): 255.649ms
	Processing time (w/o IO): 254.329ms
	Processing time (w/o IO): 258.073ms
	 Time (mean ± σ):     373.8 ms ±   9.2 ms    [User: 763.4 ms, System: 37.2 ms]
	 Range (min … max):   367.3 ms … 380.3 ms    2 runs

Generate 60000 posts
Run Benchmark (30k posts)
Running Nim Concurrent
using 4 threads
Nim Concurrent:

	Benchmark 1: ./build/related_con
	Processing time (w/o IO): 2281.08ms
	Processing time (w/o IO): 2281.354ms
	Processing time (w/o IO): 2280.384ms
	 Time (mean ± σ):      2.665 s ±  0.008 s    [User: 6.500 s, System: 0.109 s]
	 Range (min … max):    2.660 s …  2.670 s    2 runs
```

`main` == `nim_con` with clang without PGO
```
Run Benchmark (5k posts)
Running Nim Concurrent
using 4 threads
Nim Concurrent:

	Benchmark 1: ./build/related_con
	Processing time (w/o IO): 22.048ms
	Processing time (w/o IO): 21.769ms
	Processing time (w/o IO): 21.51ms
	Processing time (w/o IO): 21.755ms
	Processing time (w/o IO): 22.158ms
	Processing time (w/o IO): 22.232ms
	Processing time (w/o IO): 22.278ms
	Processing time (w/o IO): 21.969ms
	Processing time (w/o IO): 21.826ms
	Processing time (w/o IO): 22.218ms
	Processing time (w/o IO): 22.031ms
	Processing time (w/o IO): 21.866ms
	Processing time (w/o IO): 21.843ms
	 Time (mean ± σ):      52.8 ms ±   1.1 ms    [User: 72.9 ms, System: 13.9 ms]
	 Range (min … max):    51.2 ms …  54.4 ms    10 runs
	
Checking output
Success: related_posts_nim_con.json is valid!

Generate 20000 posts
Run Benchmark (15k posts)
Running Nim Concurrent
using 4 threads
Nim Concurrent:

	Benchmark 1: ./build/related_con
	Processing time (w/o IO): 297.606ms
	Processing time (w/o IO): 298.341ms
	Processing time (w/o IO): 296.255ms
	 Time (mean ± σ):     414.7 ms ±   6.9 ms    [User: 874.9 ms, System: 41.4 ms]
	 Range (min … max):   409.8 ms … 419.6 ms    2 runs
	
Generate 60000 posts
Run Benchmark (30k posts)
Running Nim Concurrent
using 4 threads
Nim Concurrent:

	Benchmark 1: ./build/related_con
	Processing time (w/o IO): 2677.794ms
	Processing time (w/o IO): 2676.803ms
	Processing time (w/o IO): 2680.33ms
	 Time (mean ± σ):      3.064 s ±  0.006 s    [User: 7.507 s, System: 0.089 s]
	 Range (min … max):    3.060 s …  3.068 s    2 runs
```