### PR TITLE
[Nim Con] switch to taskpools and general improvements

### DIFF
--- a/nim_con/.gitignore
+++ b/nim_con/.gitignore
@@ -1,3 +1,3 @@
 build/
-default.prof*
+default*.prof*
 nimcache/

--- a/nim_con/build.sh
+++ b/nim_con/build.sh
@@ -2,22 +2,6 @@
 
 set -eo pipefail
 
-nproc=${1}
-if [[ -z "${nproc}" ]]; then
-    nproc=4
-fi
-## hardwired
-# nproc=4
-
-threads=$((1 * ${nproc}))
-
-chansize=${2}
-if [[ -z "${chansize}" ]]; then
-    chansize=$((2 * ${threads}))
-fi
-## hardwired
-# chansize=16
-
 if [[ ${DANGER} = true ]]; then
     build_kind=danger
 else
@@ -26,7 +10,5 @@ fi
 
 rm -rf nimcache
 
-nim c -d:FixedChanSize=${chansize} \
-      -d:ThreadPoolSize=${threads} \
-      -d:${build_kind} \
+nim c -d:${build_kind} \
       related_con.nim

--- a/nim_con/build.sh
+++ b/nim_con/build.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+nproc=${1}
+if [[ -z "${nproc}" ]]; then
+    nproc=4
+fi
+## hardwired
+# nproc=4
+
+threads=$((1 * ${nproc}))
+
+chansize=${2}
+if [[ -z "${chansize}" ]]; then
+    chansize=$((2 * ${threads}))
+fi
+## hardwired
+# chansize=16
+
+if [[ ${DANGER} = true ]]; then
+    build_kind=danger
+else
+    build_kind=release
+fi
+
+rm -rf nimcache
+
+nim c -d:FixedChanSize=${chansize} \
+      -d:ThreadPoolSize=${threads} \
+      -d:${build_kind} \
+      related_con.nim

--- a/nim_con/build.sh
+++ b/nim_con/build.sh
@@ -8,7 +8,25 @@ else
     build_kind=release
 fi
 
+compiler="${1}"
+if [[ -z "${compiler}" ]]; then
+    if [[ $(uname) = Darwin ]]; then
+        compiler=clang
+    else
+        compiler=gcc
+    fi
+fi
+## hardwired
+# compiler=clang
+
+echo
+echo "\${compiler} = ${compiler}"
+echo "${compiler}" --version
+"${compiler}" --version
+echo
+
 rm -rf nimcache
 
 nim c -d:${build_kind} \
+      --cc:"${compiler}" \
       related_con.nim

--- a/nim_con/buildopt.sh
+++ b/nim_con/buildopt.sh
@@ -2,34 +2,17 @@
 
 set -eo pipefail
 
-nproc=${1}
-if [[ -z "${nproc}" ]]; then
-    nproc=4
-fi
-## hardwired
-# nproc=4
-
-threads=$((1 * ${nproc}))
-
-chansize=${2}
-if [[ -z "${chansize}" ]]; then
-    chansize=$((2 * ${threads}))
-fi
-## hardwired
-# chansize=16
-
 if [[ ${DANGER} = true ]]; then
     build_kind=danger
 else
     build_kind=release
 fi
 
-echo "Compiling profiled executable"
 rm -rf default*.prof* nimcache
-nim c -d:FixedChanSize=${chansize} \
-      -d:ThreadPoolSize=${threads} \
+
+echo "Compiling profiled executable"
+nim c -d:${build_kind} \
       -d:profileGen \
-      -d:${build_kind} \
       related_con.nim
 
 echo "Generating profile"
@@ -50,8 +33,6 @@ if [[ "$(cc --version 2>/dev/null | head -1)" = *"clang"* ]]; then
 fi
 
 echo "Compiling optimized executable"
-nim c -d:FixedChanSize=${chansize} \
-      -d:ThreadPoolSize=${threads} \
+nim c -d:${build_kind} \
       -d:profileUse \
-      -d:${build_kind} \
       related_con.nim

--- a/nim_con/buildopt.sh
+++ b/nim_con/buildopt.sh
@@ -8,10 +8,28 @@ else
     build_kind=release
 fi
 
+compiler="${1}"
+if [[ -z "${compiler}" ]]; then
+    if [[ $(uname) = Darwin ]]; then
+        compiler=clang
+    else
+        compiler=gcc
+    fi
+fi
+## hardwired
+# compiler=clang
+
+echo
+echo "\${compiler} = ${compiler}"
+echo "${compiler}" --version
+"${compiler}" --version
+echo
+
 rm -rf default*.prof* nimcache
 
 echo "Compiling profiled executable"
 nim c -d:${build_kind} \
+      --cc:"${compiler}" \
       -d:profileGen \
       related_con.nim
 
@@ -24,7 +42,7 @@ cd nim_con
 cd ..
 mv posts_orig.json posts.json
 cd nim_con
-if [[ "$(cc --version 2>/dev/null | head -1)" = *"clang"* ]]; then
+if [[ "${compiler}" = *"clang"* ]]; then
     if [[ -n "$(which xcrun 2>/dev/null)" ]]; then
         xcrun llvm-profdata merge default*.profraw --output default.profdata
     else
@@ -34,5 +52,6 @@ fi
 
 echo "Compiling optimized executable"
 nim c -d:${build_kind} \
+      --cc:"${compiler}" \
       -d:profileUse \
       related_con.nim

--- a/nim_con/buildopt.sh
+++ b/nim_con/buildopt.sh
@@ -33,7 +33,14 @@ nim c -d:FixedChanSize=${chansize} \
       related_con.nim
 
 echo "Generating profile"
+cd ..
+cp posts.json posts_orig.json
+python gen_fake_posts.py 60000
+cd nim_con
 ./build/related_con >/dev/null
+cd ..
+mv posts_orig.json posts.json
+cd nim_con
 if [[ "$(cc --version 2>/dev/null | head -1)" = *"clang"* ]]; then
     if [[ -n "$(which xcrun 2>/dev/null)" ]]; then
         xcrun llvm-profdata merge default*.profraw --output default.profdata

--- a/nim_con/config.nims
+++ b/nim_con/config.nims
@@ -8,7 +8,6 @@ const
 
 switch("nimcache", cacheSubdir)
 
---cc:clang
 --mm:arc
 --outdir:build
 --tlsEmulation:off # default on|off varies by platform
@@ -16,12 +15,12 @@ switch("nimcache", cacheSubdir)
 
 when defined(profileGen):
   --hints:off
-  --passC:"-fprofile-instr-generate"
-  --passL:"-fprofile-instr-generate"
+  --passC:"-fprofile-generate"
+  --passL:"-fprofile-generate"
 
 when defined(profileUse):
-  --passC:"-fprofile-instr-use"
-  --passL:"-fprofile-instr-use"
+  --passC:"-fprofile-use"
+  --passL:"-fprofile-use"
 
 when defined(release):
   --passC:"-flto"

--- a/nim_con/config.nims
+++ b/nim_con/config.nims
@@ -23,8 +23,8 @@ when defined(profileUse):
   --passL:"-fprofile-use"
 
 when defined(release):
-  --passC:"-flto"
-  --passL:"-flto"
+  --passC:"-flto=auto"
+  --passL:"-flto=auto"
   when not defined(profileGen):
     --passL:"-s"
 else:

--- a/nim_con/config.nims
+++ b/nim_con/config.nims
@@ -11,7 +11,6 @@ switch("nimcache", cacheSubdir)
 --mm:arc
 --outdir:build
 --tlsEmulation:off # default on|off varies by platform
---warning:"Effect:off" # suppress noisy compiler warnings re: malebolgia
 
 when defined(profileGen):
   --hints:off

--- a/nim_con/related_con.nim
+++ b/nim_con/related_con.nim
@@ -47,7 +47,7 @@ func `==`(x, y: Tag): bool {.borrow.}
 func `[]`(groups: TaskGroups, i: int): TaskGroup =
   groups.groups[i]
 
-proc dumpHook(s: var string, v: ptr) {.used.} =
+proc dumpHook(s: var string, v: ptr) {.inline, used.} =
   if v == nil:
     s.add("null")
   else:
@@ -73,6 +73,8 @@ func init(T: typedesc[TaskGroups], taskCount: int): T =
     if i == ThreadPoolSize - 1:
       groups[i].last = groups[i].last + taskCount mod ThreadPoolSize
   T(groups: groups, size: groups.len)
+
+{.push inline.}
 
 proc tally(
     counts: var seq[RelCount],
@@ -117,6 +119,8 @@ proc process(
     postsOut[index].`"_id"` = posts[index].`"_id"`
     postsOut[index].tags = addr posts[index].tags
     counts.topN(posts, metas, postsOut[index].related)
+
+{.pop.}
 
 proc readPosts(path: string): seq[Post] =
   path.readFile.fromJson(seq[Post])

--- a/nim_con/related_con.nimble
+++ b/nim_con/related_con.nimble
@@ -5,5 +5,5 @@ license       = "MIT"
 
 requires "nim >= 2.0.0",
          "jsony#head",
-         "malebolgia#head",
+         "taskpools#head",
          "xxhash"

--- a/run.sh
+++ b/run.sh
@@ -490,7 +490,7 @@ run_nim_con() {
         echo "using ${nproc} threads" &&
         if [ -z "$appendToFile" ]; then # only build on 5k run
             nimble -y install -d &&
-                ./buildopt.sh ${nproc}
+                ./build.sh ${nproc}
         fi &&
         if [ $HYPER == 1 ]; then
             capture "Nim Concurrent" hyperfine -r $runs -w $warmup --show-output "./build/related_con"

--- a/run.sh
+++ b/run.sh
@@ -487,10 +487,9 @@ run_nim() {
 run_nim_con() {
     echo "Running Nim Concurrent" &&
         cd ./nim_con &&
-        echo "using ${nproc} threads" &&
         if [ -z "$appendToFile" ]; then # only build on 5k run
             nimble -y install -d &&
-                ./build.sh ${nproc}
+                ./build.sh
         fi &&
         if [ $HYPER == 1 ]; then
             capture "Nim Concurrent" hyperfine -r $runs -w $warmup --show-output "./build/related_con"


### PR DESCRIPTION
Alternative to and closes #351.

Independent of the PGO work in open PR #351, I was able to make the `nim_com` implementation more efficient.

I also found that by switching from [`malebolgia`](https://github.com/Araq/malebolgia) to [`taskpools`](https://github.com/status-im/nim-taskpools), all available cores are better utilized[^1].

With these changes in `nim_con/related_con.nim`, clang or gcc PGO consistently decreases performance, so PGO is not used by default, i.e. `run.sh` invokes `nim_con/build.sh` instead of `nim_con/buildopt.sh`[^2].

With PGO ***not*** in the mix, the performance numbers seem to not bounce around too much.

For these changes, `gcc` builds perform better than `clang` builds.

It's now easy to switch compilers when invoking `build.sh` and `buildopt.sh`,  e.g. to use `clang` instead of `gcc` do `./build.sh clang`.

A `dumpHook` is introduced for automatic use with/by the `jsony` library. Note that it does no more and no less work during the serialization step (i.e. after processing time is calculated) than `jsony` is already doing in single-threaded `nim` for `ref` types: [jsony.nim#L851-L855](https://github.com/treeform/jsony/blob/master/src/jsony.nim#L851-L855).

[^1]: I think there's a bug in `malebolgia` because it's consistently saturating only `N - 1` cores with `N` cores available. Or maybe that's by design to keep the main thread freed up in more complex synchronization scenarios, I'm not sure.

[^2]: I [investigated](https://github.com/jinyus/related_post_gen/pull/351#issuecomment-1773530346) the too-bouncy performance re: PGO builds, but didn't reach a firm conclusion.