### PR TITLE
[Nim] test overflow checks disabled

### DIFF
--- a/nim/config.nims
+++ b/nim/config.nims
@@ -3,6 +3,7 @@ switch("cc", "gcc")
 switch("panics", "off")
 switch("passC", "-s -flto")
 switch("passL", "-s -flto")
+switch("overflowChecks", "off")
 
 when defined(profileGen):
   echo "Build with profileGen"


### PR DESCRIPTION
The PR just to check only.

The reasons for it:
- Rust does not have the check in `release` mode at all
- Cpp does not have it at all
