### PR TITLE
[Nim Con] speedup with default hash

### DIFF
--- a/nim_con/build.sh
+++ b/nim_con/build.sh
@@ -2,6 +2,11 @@
 
 set -eo pipefail
 
+echo
+echo "origin: $(git remote get-url origin)"
+echo "branch: $(git rev-parse --abbrev-ref HEAD)"
+echo "commit: $(git rev-parse HEAD | cut -c1-7)"
+
 if [[ ${DANGER} = true ]]; then
     build_kind=danger
 else
@@ -20,13 +25,13 @@ fi
 # compiler=clang
 
 echo
-echo "\${compiler} = ${compiler}"
+echo "\$compiler=${compiler}"
 echo "${compiler}" --version
 "${compiler}" --version
-echo
 
 rm -rf nimcache
 
+echo
 nim c -d:${build_kind} \
       --cc:"${compiler}" \
       related_con.nim

--- a/nim_con/buildopt.sh
+++ b/nim_con/buildopt.sh
@@ -2,6 +2,11 @@
 
 set -eo pipefail
 
+echo
+echo "origin: $(git remote get-url origin)"
+echo "branch: $(git rev-parse --abbrev-ref HEAD)"
+echo "commit: $(git rev-parse HEAD | cut -c1-7)"
+
 if [[ ${DANGER} = true ]]; then
     build_kind=danger
 else
@@ -20,19 +25,20 @@ fi
 # compiler=clang
 
 echo
-echo "\${compiler} = ${compiler}"
+echo "\$compiler=${compiler}"
 echo "${compiler}" --version
 "${compiler}" --version
-echo
 
 rm -rf default*.prof* nimcache
 
+echo
 echo "Compiling profiled executable"
 nim c -d:${build_kind} \
       --cc:"${compiler}" \
       -d:profileGen \
       related_con.nim
 
+echo
 echo "Generating profile"
 cd ..
 cp posts.json posts_orig.json
@@ -50,6 +56,7 @@ if [[ "${compiler}" = *"clang"* ]]; then
     fi
 fi
 
+echo
 echo "Compiling optimized executable"
 nim c -d:${build_kind} \
       --cc:"${compiler}" \

--- a/nim_con/buildopt.sh
+++ b/nim_con/buildopt.sh
@@ -34,8 +34,8 @@ rm -rf default*.prof* nimcache
 echo
 echo "Compiling profiled executable"
 nim c -d:${build_kind} \
-      --cc:"${compiler}" \
       -d:profileGen \
+      --cc:"${compiler}" \
       related_con.nim
 
 echo
@@ -59,6 +59,6 @@ fi
 echo
 echo "Compiling optimized executable"
 nim c -d:${build_kind} \
-      --cc:"${compiler}" \
       -d:profileUse \
+      --cc:"${compiler}" \
       related_con.nim

--- a/nim_con/related_con.nim
+++ b/nim_con/related_con.nim
@@ -72,6 +72,12 @@ func init(T: typedesc[TaskGroups], taskCount, groupCount: int): T =
       groups[i].last = groups[i].last + taskCount mod groupCount
   T(groups: groups, size: groups.len)
 
+proc readPosts(path: string): seq[Post] =
+  path.readFile.fromJson(seq[Post])
+
+proc writePosts(path: string, posts: seq[PostOut]) =
+  path.writeFile(posts.toJson)
+
 {.push inline.}
 
 proc tally(
@@ -123,9 +129,6 @@ proc process(
 
 {.pop.}
 
-proc readPosts(path: string): seq[Post] =
-  path.readFile.fromJson(seq[Post])
-
 proc main() =
   let
     posts = input.readPosts
@@ -141,7 +144,7 @@ proc main() =
   tp.syncAll
   let time = (getMonotime() - t0).inMicroseconds / 1000
   echo "Processing time (w/o IO): ", time, "ms"
-  output.writeFile(postsOut.toJson)
+  output.writePosts(postsOut)
   tp.shutdown
 
 when isMainModule:

--- a/nim_con/related_con.nim
+++ b/nim_con/related_con.nim
@@ -1,5 +1,5 @@
 import std/[cpuinfo, hashes, monotimes, times]
-import pkg/[jsony, taskpools, xxhash]
+import pkg/[jsony, taskpools]
 import ./related_con/fixedtable
 
 const N: Positive = 5
@@ -21,7 +21,7 @@ type
 
   RelMeta = tuple[count: RelCount, index: PostIndex]
 
-  Tag = distinct string
+  Tag = string
 
   TagMap = Table[Tag, seq[PostIndex]]
 
@@ -37,11 +37,6 @@ const
   input = "../posts.json"
   output = "../related_posts_nim_con.json"
 
-func `$`(x: Tag): string =
-  x.string
-
-func `==`(x, y: Tag): bool {.borrow.}
-
 func `[]`(groups: TaskGroups, i: int): TaskGroup =
   groups.groups[i]
 
@@ -50,9 +45,6 @@ proc dumpHook(s: var string, v: ptr) {.inline, used.} =
     s.add("null")
   else:
     s.dumpHook(v[])
-
-func hash(x: Tag): Hash {.used.} =
-  cast[Hash](XXH3_64bits($x))
 
 func init(T: typedesc[TagMap], posts: seq[Post]): T =
   result = initTable[Tag, seq[PostIndex]](100)

--- a/nim_con/related_con.nim
+++ b/nim_con/related_con.nim
@@ -2,9 +2,7 @@ import std/[cpuinfo, hashes, monotimes, times]
 import pkg/[jsony, taskpools, xxhash]
 import ./related_con/fixedtable
 
-const N = 5
-when N < 1:
-  {.fatal: "N must be greater than zero!".}
+const N: Positive = 5
 
 type
   Post = object

--- a/nim_con/related_con.nim
+++ b/nim_con/related_con.nim
@@ -63,13 +63,13 @@ func init(T: typedesc[TagMap], posts: seq[Post]): T =
       do:
         result[tag] = @[i]
 
-func init(T: typedesc[TaskGroups], threadCount, taskCount: int): T =
-  var groups = newSeqOfCap[TaskGroup](threadCount)
-  let step = taskCount div threadCount
-  for i in 0..<threadCount:
-    groups.add((first: step * i, last: step * (i + 1) - 1))
-    if i == threadCount - 1:
-      groups[i].last = groups[i].last + taskCount mod threadCount
+func init(T: typedesc[TaskGroups], taskCount, groupCount: int): T =
+  var groups = newSeqOfCap[TaskGroup](groupCount)
+  let width = taskCount div groupCount
+  for i in 0..<groupCount:
+    groups.add((first: width * i, last: width * (i + 1) - 1))
+    if i == groupCount - 1:
+      groups[i].last = groups[i].last + taskCount mod groupCount
   T(groups: groups, size: groups.len)
 
 {.push inline.}
@@ -131,7 +131,7 @@ proc main() =
     posts = input.readPosts
     t0 = getMonotime()
     threadCount = countProcessors()
-    groups = TaskGroups.init(threadCount, posts.len)
+    groups = TaskGroups.init(posts.len, threadCount)
     tagMap = TagMap.init(posts)
   var
     postsOut = newSeq[PostOut](posts.len)

--- a/nim_con/related_con.nimble
+++ b/nim_con/related_con.nimble
@@ -5,5 +5,4 @@ license       = "MIT"
 
 requires "nim >= 2.0.0",
          "jsony#head",
-         "taskpools#head",
-         "xxhash"
+         "taskpools#head"

--- a/run.sh
+++ b/run.sh
@@ -489,7 +489,7 @@ run_nim_con() {
         cd ./nim_con &&
         if [ -z "$appendToFile" ]; then # only build on 5k run
             nimble -y install -d &&
-                ./build.sh
+                ./build.sh clang
         fi &&
         if [ $HYPER == 1 ]; then
             capture "Nim Concurrent" hyperfine -r $runs -w $warmup --show-output "./build/related_con"


### PR DESCRIPTION
I found there's a modest but consistent performance improvement if I drop `xxhash` and (automatically) use Nim's default hash for `TagMap`, *and* switch back to clang.

Now, `xxhash` is definitely faster than Nim's default hash in a straight benchmark. But for this code, the combination of inlining hints, the default hash, *and* clang gives a better result.