### PR TITLE
Stabilize performance of Julia implementation

### DIFF
--- a/julia/Related/src/Related.jl
+++ b/julia/Related/src/Related.jl
@@ -47,7 +47,6 @@ function related(posts)
     # key is every possible "tag" used in all posts
     # value is indicies of all "post"s that used this tag
     tagmap = Dict{String,Vector{T}}()
-    sizehint!(tagmap, 100)
     for (idx, post) in enumerate(posts)
         for tag in post.tags
             tags = get!(() -> T[], tagmap, tag)

--- a/julia/Related/src/Related.jl
+++ b/julia/Related/src/Related.jl
@@ -20,13 +20,14 @@ end
 
 StructTypes.StructType(::Type{PostData}) = StructTypes.Struct()
 
-function fastmaxindex!(xs::Vector{T}, topn, maxn, maxv) where {T}
-    maxn .= one(T)
-    maxv .= zero(T)
+function fastmaxindex!(xs::Vector, topn, maxn, maxv)
+    maxn .= 1
+    maxv .= 0
     top = maxv[1]
     for (i, x) in enumerate(xs)
         if x > top
-            maxn[1], maxv[1] = i, x
+            maxv[1] = x
+            maxn[1] = i
             for j in 2:topn
                 if maxv[j-1] > maxv[j]
                     maxv[j-1], maxv[j] = maxv[j], maxv[j-1]
@@ -37,7 +38,7 @@ function fastmaxindex!(xs::Vector{T}, topn, maxn, maxv) where {T}
         end
     end
     reverse!(maxn)
-    return 
+    return maxn
 end
 
 function related(posts)
@@ -46,6 +47,7 @@ function related(posts)
     # key is every possible "tag" used in all posts
     # value is indicies of all "post"s that used this tag
     tagmap = Dict{String,Vector{T}}()
+    sizehint!(tagmap, 100)
     for (idx, post) in enumerate(posts)
         for tag in post.tags
             tags = get!(() -> T[], tagmap, tag)
@@ -60,7 +62,7 @@ function related(posts)
     maxv = MVector{topn,T}(undef)
 
     for (i, post) in enumerate(posts)
-        taggedpostcount .= zero(T)
+        taggedpostcount .= 0
         # for each post (`i`-th)
         # and every tag used in the `i`-th post
         # give all related post +1 in `taggedpostcount` shadow vector
@@ -71,7 +73,7 @@ function related(posts)
         end
 
         # don't self count
-        taggedpostcount[i] = zero(T)
+        taggedpostcount[i] = 0
 
         fastmaxindex!(taggedpostcount, topn, maxn, maxv)
 

--- a/julia_con/RelatedCon/src/RelatedCon.jl
+++ b/julia_con/RelatedCon/src/RelatedCon.jl
@@ -21,12 +21,13 @@ end
 
 
 function fastmaxindex!(xs::Vector, topn, maxn, maxv)
-    maxn .= one(UInt32)
-    maxv .= zero(UInt32)
+    maxn .= 1
+    maxv .= 0
     top = maxv[1]
     for (i, x) in enumerate(xs)
         if x > top
-            maxn[1], maxv[1] = i, x
+            maxn[1] = i
+            maxv[1] = x
             for j in 2:topn
                 if maxv[j-1] > maxv[j]
                     maxv[j-1], maxv[j] = maxv[j], maxv[j-1]
@@ -37,7 +38,7 @@ function fastmaxindex!(xs::Vector, topn, maxn, maxv)
         end
     end
     reverse!(maxn)
-    return
+    return maxn
 end
 
 function related(posts)
@@ -62,7 +63,7 @@ function related(posts)
         for i in postsrange
             post = posts[i]
 
-            taggedpostcount .= zero(UInt32)
+            taggedpostcount .= 0
             # for each post (`i`-th)
             # and every tag used in the `i`-th post
             # give all related post +1 in `taggedpostcount` shadow vector
@@ -72,7 +73,7 @@ function related(posts)
                 end
             end
             # don't self count
-            taggedpostcount[i] = zero(UInt32)
+            taggedpostcount[i] = 0
 
             fastmaxindex!(taggedpostcount, topn, maxn, maxv)
 


### PR DESCRIPTION
This is very weird...but I don't see anymore the times changing from around 23 ms to 30 ms with restarting if we go back to this implementation. Only nearly 23 ms. On the last VM results I saw the same behaviour as on my machine, so I hope the same happens on the VM

@Moelf 

Can you please check on the VM @jinyus ?