### PR TITLE
reorder to move parts into functions, switch to c++20 and gcc

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -100,7 +100,7 @@ run_cpp() {
     echo "Running C++" &&
         cd ./cpp &&
         if [ -z "$appendToFile" ]; then # only build on 5k run
-            clang++ -std=c++11 -I./include -O3 main.cpp -o main
+            g++ -O3 -std=c++20  -I./include main.cpp -o main
         fi &&
         if [ $HYPER == 1 ]; then
             capture "C++" hyperfine -r $runs -w $warmup --show-output "./main"


### PR DESCRIPTION
- Moved the various parts into functions to show that one doesn't have to use a single large main function.
- some small performance improvements int top5 logic by improving memory locality.
- moved to gcc & c++20 since that was the fastest after changes.

@jinyus would be curious to see how this performs on the VM.

(Tried adding better maps but only got better results when using `march=x86_64_v3` but seems like that is forbidden here from what I understand)