### PR TITLE
Apply go tweaks to go_con

### DIFF
--- a/go_con/main.go
+++ b/go_con/main.go
@@ -28,7 +28,7 @@ type Post struct {
 
 type PostWithSharedTags struct {
 	Post       isize
-	SharedTags isize
+	SharedTags byte
 }
 
 type RelatedPosts struct {
@@ -78,7 +78,7 @@ func main() {
 	var w isize
 	for ; w < isize(concurrency); w++ {
 		// allocate taggedPostCount for each worker once, zero out for each task
-		taggedPostCount := make([]isize, postsLengthISize)
+		taggedPostCount := make([]byte, postsLengthISize)
 		go func(workerID isize) {
 			for i := workerID; i < postsLengthISize; i += concurrency {
 				// provide taggedPostCount and binary heap for each task
@@ -113,7 +113,7 @@ func main() {
 	}
 }
 
-func computeRelatedPost(i isize, posts []Post, tagMap map[string][]isize, taggedPostCount []isize) RelatedPosts {
+func computeRelatedPost(i isize, posts []Post, tagMap map[string][]isize, taggedPostCount []byte) RelatedPosts {
 	// Zero out tagged post count
 	for j := range taggedPostCount {
 		taggedPostCount[j] = 0
@@ -129,12 +129,12 @@ func computeRelatedPost(i isize, posts []Post, tagMap map[string][]isize, tagged
 	taggedPostCount[i] = 0 // Don't count self
 
 	top5 := [topN]PostWithSharedTags{}
-	minTags := isize(0) // Updated initialization
+	minTags := byte(0) // Updated initialization
 
 	for j, count := range taggedPostCount {
 		if count > minTags {
 			// Find the position to insert
-			pos := 4
+			pos := 3
 			for pos >= 0 && top5[pos].SharedTags < count {
 				pos--
 			}

--- a/go_con/main.go
+++ b/go_con/main.go
@@ -28,7 +28,7 @@ type Post struct {
 
 type PostWithSharedTags struct {
 	Post       isize
-	SharedTags byte
+	SharedTags isize
 }
 
 type RelatedPosts struct {
@@ -78,7 +78,7 @@ func main() {
 	var w isize
 	for ; w < isize(concurrency); w++ {
 		// allocate taggedPostCount for each worker once, zero out for each task
-		taggedPostCount := make([]byte, postsLengthISize)
+		taggedPostCount := make([]isize, postsLengthISize)
 		go func(workerID isize) {
 			for i := workerID; i < postsLengthISize; i += concurrency {
 				// provide taggedPostCount and binary heap for each task
@@ -113,7 +113,7 @@ func main() {
 	}
 }
 
-func computeRelatedPost(i isize, posts []Post, tagMap map[string][]isize, taggedPostCount []byte) RelatedPosts {
+func computeRelatedPost(i isize, posts []Post, tagMap map[string][]isize, taggedPostCount []isize) RelatedPosts {
 	// Zero out tagged post count
 	for j := range taggedPostCount {
 		taggedPostCount[j] = 0
@@ -129,7 +129,7 @@ func computeRelatedPost(i isize, posts []Post, tagMap map[string][]isize, tagged
 	taggedPostCount[i] = 0 // Don't count self
 
 	top5 := [topN]PostWithSharedTags{}
-	minTags := byte(0) // Updated initialization
+	minTags := isize(0) // Updated initialization
 
 	for j, count := range taggedPostCount {
 		if count > minTags {


### PR DESCRIPTION
Applies optimizations from #395 to go_con.

Seems to be slower...(tested twice with same results)

Main:
`Go Concurrent | 12.19 ms | 164.52 ms | 1.43 s`

This PR:
```
Go Concurrent:

        Benchmark 1: ./related_concurrent
        Processing time (w/o IO): 12.449775ms
        Processing time (w/o IO): 14.2278ms
        Processing time (w/o IO): 12.854681ms
        Processing time (w/o IO): 12.754979ms
        Processing time (w/o IO): 12.81938ms
        Processing time (w/o IO): 12.571376ms
        Processing time (w/o IO): 12.623178ms
        Processing time (w/o IO): 12.324273ms
        Processing time (w/o IO): 14.777608ms
        Processing time (w/o IO): 12.512376ms
        Processing time (w/o IO): 12.364274ms
        Processing time (w/o IO): 12.278273ms
        Processing time (w/o IO): 12.388574ms
          Time (mean ± σ):      52.8 ms ±   1.9 ms    [User: 84.4 ms, System: 9.9 ms]
          Range (min … max):    50.2 ms …  56.7 ms    10 runs
         
Go Concurrent:

        Benchmark 1: ./related_concurrent
        Processing time (w/o IO): 171.469112ms
        Processing time (w/o IO): 171.561813ms
        Processing time (w/o IO): 172.486126ms
          Time (mean ± σ):     315.1 ms ±   0.4 ms    [User: 809.5 ms, System: 35.4 ms]
          Range (min … max):   314.8 ms … 315.4 ms    2 runs
         
Go Concurrent:

        Benchmark 1: ./related_concurrent
        Processing time (w/o IO): 1.487239318s
        Processing time (w/o IO): 1.488106605s
        Processing time (w/o IO): 1.494551652s
          Time (mean ± σ):      1.980 s ±  0.011 s    [User: 6.412 s, System: 0.103 s]
          Range (min … max):    1.973 s …  1.988 s    2 runs

```