### PR TITLE
[Julia] Stablize the results

### DIFF
--- a/julia/Related/src/Related.jl
+++ b/julia/Related/src/Related.jl
@@ -86,7 +86,7 @@ end
 function main()
     json_string = read(@__DIR__()*"/../../../posts.json", String)
     posts = JSON3.read(json_string, Vector{PostData})
-    fake_posts = posts[1:2]
+    fake_posts = first(posts, 1000)
     related(fake_posts) #warmup
 
     start = now()
@@ -97,5 +97,7 @@ function main()
         JSON3.write(f, all_related_posts)
     end
 end
+
+main()
 
 end # module Related

--- a/julia_con/RelatedCon/src/RelatedCon.jl
+++ b/julia_con/RelatedCon/src/RelatedCon.jl
@@ -87,7 +87,7 @@ end
 function main()
     json_string = read(@__DIR__()*"/../../../posts.json", String)
     posts = JSON3.read(json_string, Vector{PostData})
-    related(posts[1:2]) #warmup
+    related(first(posts, 1000)) #warmup
 
     start = now()
     all_related_posts = related(posts)
@@ -97,5 +97,7 @@ function main()
         JSON3.write(f, all_related_posts)
     end
 end
+
+main()
 
 end # module RelatedCon

--- a/run.sh
+++ b/run.sh
@@ -260,9 +260,9 @@ run_julia() {
         julia -e 'using Pkg; Pkg.activate("Related"); Pkg.instantiate()' &&
         if [ $HYPER == 1 ]; then
 
-            capture "Julia" hyperfine -r $runs -w $warmup --show-output "julia --project=Related -e \"using Related; main()\""
+            capture "Julia" hyperfine -r $runs -w $warmup --show-output "julia --startup-file=no --project=Related -e \"using Related; main()\""
         else
-            command ${time} -f '%es %Mk' julia --project=Related -e "using Related; main()"
+            command ${time} -f '%es %Mk' julia --startup-file=no --project=Related -e "using Related; main()"
 
         fi
 
@@ -287,9 +287,9 @@ run_julia_con() {
         cd ./julia_con &&
         julia -e 'using Pkg; Pkg.activate("RelatedCon"); Pkg.instantiate()' &&
         if [ $HYPER == 1 ]; then
-            capture "Julia Concurrent" hyperfine -r $runs -w $warmup --show-output "julia --threads=auto --project=RelatedCon -e \"using RelatedCon; main()\""
+            capture "Julia Concurrent" hyperfine -r $runs -w $warmup --show-output "julia --startup-file=no --threads=auto --project=RelatedCon -e \"using RelatedCon; main()\""
         else
-            command ${time} -f '%es %Mk' julia --threads auto --project=RelatedCon -e "using RelatedCon; main()"
+            command ${time} -f '%es %Mk' julia --startup-file=no --threads=auto --project=RelatedCon -e "using RelatedCon; main()"
         fi
 
     check_output "related_posts_julia_con.json"


### PR DESCRIPTION
tested on the same VM. I now suspect the vGPU has some policy if it sees you idle it will start shifting resource away from your VM or something

before:
```
Benchmark 1: julia --project=Related -e "using Related; main()"
Processing time (w/o IO): 31 milliseconds
Processing time (w/o IO): 23 milliseconds
Processing time (w/o IO): 24 milliseconds
Processing time (w/o IO): 25 milliseconds
Processing time (w/o IO): 30 milliseconds
Processing time (w/o IO): 31 milliseconds
Processing time (w/o IO): 25 milliseconds
```

after:
```
Benchmark 1: julia --project=Related -e "using Related; main()"
Processing time (w/o IO): 24 milliseconds
Processing time (w/o IO): 25 milliseconds
Processing time (w/o IO): 25 milliseconds
Processing time (w/o IO): 24 milliseconds
Processing time (w/o IO): 24 milliseconds
Processing time (w/o IO): 24 milliseconds
Processing time (w/o IO): 25 milliseconds
Processing time (w/o IO): 24 milliseconds
```