### PR TITLE
[julia] More accurate timings

### DIFF
--- a/julia/Related/src/Related.jl
+++ b/julia/Related/src/Related.jl
@@ -1,6 +1,6 @@
 module Related
 
-using JSON3, StructTypes, Dates, StaticArrays
+using JSON3, StructTypes, StaticArrays
 
 export main
 
@@ -89,12 +89,11 @@ function main()
     fake_posts = first(posts, 1000)
     related(fake_posts) #warmup
 
-    start = now()
-    all_related_posts = related(posts)
-    println("Processing time (w/o IO): $(now() - start)")
+    stats = @timed related(posts)
+    println("Processing time (w/o IO): $(1000*stats.time)ms")
 
     open(@__DIR__()*"/../../../related_posts_julia.json", "w") do f
-        JSON3.write(f, all_related_posts)
+        JSON3.write(f, stats.value)
     end
 end
 

--- a/julia/Related/src/Related.jl
+++ b/julia/Related/src/Related.jl
@@ -88,10 +88,8 @@ function main()
     posts = JSON3.read(json_string, Vector{PostData})
     fake_posts = first(posts, 1000)
     related(fake_posts) #warmup
-
     stats = @timed related(posts)
     println("Processing time (w/o IO): $(1000*stats.time)ms")
-
     open(@__DIR__()*"/../../../related_posts_julia.json", "w") do f
         JSON3.write(f, stats.value)
     end

--- a/julia_con/RelatedCon/src/RelatedCon.jl
+++ b/julia_con/RelatedCon/src/RelatedCon.jl
@@ -87,14 +87,12 @@ end
 function main()
     json_string = read(@__DIR__()*"/../../../posts.json", String)
     posts = JSON3.read(json_string, Vector{PostData})
-    related(first(posts, 1000)) #warmup
-
-    start = now()
-    all_related_posts = related(posts)
-    println("Processing time (w/o IO): $(now() - start)")
-
+    fake_posts = first(posts, 1000)
+    related(fake_posts) #warmup
+    stats = @timed related(posts)
+    println("Processing time (w/o IO): $(1000*stats.time)ms")
     open(@__DIR__()*"/../../../related_posts_julia_con.json", "w") do f
-        JSON3.write(f, all_related_posts)
+        JSON3.write(f, stats.value)
     end
 end
 

--- a/julia_con/RelatedCon/src/RelatedCon.jl
+++ b/julia_con/RelatedCon/src/RelatedCon.jl
@@ -1,6 +1,6 @@
 module RelatedCon
 
-using JSON3, Dates, StaticArrays, ChunkSplitters
+using JSON3, StaticArrays, ChunkSplitters
 using Base.Threads: @threads, nthreads
 
 export main


### PR DESCRIPTION
this is more accurate:

```
Processing time (w/o IO): 18.708785ms
Processing time (w/o IO): 18.180406ms
Processing time (w/o IO): 18.605787ms
Processing time (w/o IO): 17.920885000000002ms
Processing time (w/o IO): 18.325236ms
Processing time (w/o IO): 18.091424ms
Processing time (w/o IO): 18.554257ms
Processing time (w/o IO): 18.720408000000003ms
Processing time (w/o IO): 18.382645999999998ms
Processing time (w/o IO): 18.396163ms
```

before it had no decimal places