### PR TITLE
[Racket] cleanup

### DIFF
--- a/racket/related.rkt
+++ b/racket/related.rkt
@@ -7,13 +7,11 @@
 (when (< N 1)
   (error (format "N must be positive, but was ~a" N)))
 
-(struct post (_id title tags))
+(define N-1 (- N 1))
+(define N-2 (- N 2))
 
-(struct related-posts (_id tags related))
-
-(define input "../posts.json")
-
-(define output "../related_posts_racket.json")
+(struct post (_id title tags) #:prefab)
+(struct related-posts (_id tags related) #:prefab)
 
 (define (hash->post h)
   (post (hash-ref h '_id)
@@ -30,19 +28,21 @@
           'tags (map symbol->string (related-posts-tags r))
           'related (map post->hash (related-posts-related r))))
 
-(define (make-tag-map posts indices)
+(define (make-tag-map posts)
   (let ([tag-map (make-hasheq)])
-    (for* ([index (in-range indices)]
+    (for* ([index (in-range (vector-length posts))]
            [tag (in-list (post-tags (vector-ref posts index)))])
       (hash-update! tag-map
                     tag
                     (λ (related-indices) (cons index related-indices))
-                    '()))
+                    list))
     tag-map))
 
 (define (read-posts path)
-  (for/vector ([h (in-list (with-input-from-file path read-json))])
-    (hash->post h)))
+  (let ([hashes (with-input-from-file path read-json)])
+    (for/vector #:length (length hashes)
+                ([h (in-list hashes)])
+      (hash->post h))))
 
 (define (write-posts posts path)
   (with-output-to-file
@@ -51,68 +51,64 @@
                         (related-posts->hash p))))
     #:exists 'replace))
 
-(define (tally tag-map post index indices)
-  (let ([counts (make-vector indices 0)])
+(define (tally tag-map post index posts-len)
+  (let ([counts (make-vector posts-len 0)])
     (for* ([tag (in-list (post-tags post))]
            [related-index (in-list (hash-ref tag-map tag))])
       (vector-set! counts
                    related-index
-                   (+ (vector-ref counts related-index) 1)))
+                   (add1 (vector-ref counts related-index))))
     (vector-set! counts index 0) ;; remove self
     counts))
 
-(define (top-n counts posts indices)
+(define (top-n counts posts posts-len)
   (let ([min-count 0]
         [top-counts (make-vector N 0)]
         [top-indices (make-vector N 0)])
-    (for ([index (in-range indices)])
+    (for ([index (in-range posts-len)])
       (let ([count (vector-ref counts index)])
         (when (> count min-count)
-          (let loop ([rank (- N 2)])
+          (let loop ([rank N-2])
             (if (and (>= rank 0)
                      (> count (vector-ref top-counts rank)))
-              (loop (- rank 1))
-              (let ([rank (+ rank 1)])
-                (when (< rank (- N 1))
-                  (for ([rank (in-inclusive-range (- N 2) rank -1)])
+              (loop (sub1 rank))
+              (let ([rank (add1 rank)])
+                (when (< rank N-1)
+                  (for ([rank (in-inclusive-range N-2 rank -1)])
                     (vector-set! top-counts
-                                 (+ rank 1)
+                                 (add1 rank)
                                  (vector-ref top-counts rank))
                     (vector-set! top-indices
-                                 (+ rank 1)
+                                 (add1 rank)
                                  (vector-ref top-indices rank))))
                 (vector-set! top-counts rank count)
                 (vector-set! top-indices rank index)
                 (set! min-count
-                      (vector-ref top-counts (- N 1)))))))))
+                      (vector-ref top-counts N-1))))))))
     (for/list ([index (in-vector top-indices)])
       (vector-ref posts index))))
 
 (define (process posts)
-  (let* ([indices (vector-length posts)]
-         [related (make-vector indices (related-posts "" '() '()))]
-         [tag-map (make-tag-map posts indices)])
-    (for ([index (in-range indices)])
+  (let ([posts-len (vector-length posts)]
+        [tag-map (make-tag-map posts)])
+    (for/vector #:length posts-len
+                ([index (in-range posts-len)])
       (let* ([post (vector-ref posts index)]
-             [counts (tally tag-map post index indices)])
-        (vector-set! related
-                     index
-                     (related-posts (post-_id post)
-                                    (post-tags post)
-                                    (top-n counts posts indices)))))
-    related))
+             [counts (tally tag-map post index posts-len)])
+        (related-posts (post-_id post)
+                       (post-tags post)
+                       (top-n counts posts posts-len))))))
 
-(define posts (read-posts input))
-
-(collect-garbage)
-
-(define start-time (current-inexact-monotonic-milliseconds))
-
-(define related (process posts))
-
-(define end-time (current-inexact-monotonic-milliseconds))
-
-(write-posts related output)
-
-(printf "Processing time (w/o IO): ~ams~n"
-        (real->decimal-string (- end-time start-time)))
+(module+ main
+  ;; `input` and `output` paths are relative to directory of this script
+  ;; cli exec: $ racket related.rkt
+  (define input "../posts.json")
+  (define output "../related_posts_racket.json")
+  (define posts (read-posts input))
+  (collect-garbage)
+  (define start-time (current-inexact-monotonic-milliseconds))
+  (define related (process posts))
+  (define end-time (current-inexact-monotonic-milliseconds))
+  (write-posts related output)
+  (printf "Processing time (w/o IO): ~ams~n"
+          (real->decimal-string (- end-time start-time) 2)))

--- a/run.sh
+++ b/run.sh
@@ -1128,6 +1128,7 @@ elif [ "$first_arg" = "all" ]; then
         run_erlang || echo -e "\n" &&
         # run_ruby || echo -e "\n" && # too slow
         # run_dascript || echo -e "\n" && #not installed in docker
+        run_racket || echo -e "\n" &&
         run_lobster_jit || echo -e "\n" &&
         run_lobster_cpp || echo -e "\n" &&
         run_scala_native || echo -e "\n" &&


### PR DESCRIPTION
After experimentation with a more functional approach, I wasn't able to improve performance of the single-threaded Racket impl over what I achieved with `vector` and mutation — I guess it's pretty hard to beat constant time read/write afforded by `vector-ref` and `vector-set!`.

However, in the process and also while working on a Typed Racket impl (PR coming shortly) I did cleanup the code a bit.

Note: runtime numbers in the VM/Docker are pretty bouncy, probably because of Racket's garbage collector, but there's no baseline anyway so these changes are good-to-go from my perspective.

Should I add `run_racket` to `all`?

 I didn't get any feedback/tips, yet, from the Racket community, but maybe someone will have ideas in the future.