### PR TITLE
[Racket] install racket instead of racket-minimal in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -86,11 +86,7 @@ RUN pacman -S --noconfirm --needed leiningen stack
 RUN pacman -S --noconfirm --needed ruby
 
 # install racket
-RUN pacman -S --noconfirm --needed racket-minimal
-RUN raco pkg install --auto --no-docs compiler-lib
-# additional deps needed for Typed Racket, disabled for now
-# RUN pacman -S --noconfirm --needed racket-minimal cairo fontconfig pango
-# RUN raco pkg install --auto --no-docs compiler-lib typed-racket-more
+RUN pacman -S --noconfirm --needed racket
 
 # install lobster
 RUN pacman -S --noconfirm --needed cmake

--- a/run.sh
+++ b/run.sh
@@ -789,12 +789,12 @@ run_racket() {
         if [ -z "$appendToFile" ]; then # only build on 5k run
             raco pkg install --auto --name related --no-docs --skip-installed &&
                 raco make related.rkt
+        fi &&
+        if [ $HYPER == 1 ]; then
+            capture "Racket" hyperfine -r $runs -w $warmup --show-output "racket related.rkt"
+        else
+            command ${time} -f '%es %Mk' racket related.rkt
         fi
-    if [ $HYPER == 1 ]; then
-        capture "Racket" hyperfine -r $runs -w $warmup --show-output "racket related.rkt"
-    else
-        command ${time} -f '%es %Mk' racket related.rkt
-    fi
 
     check_output "related_posts_racket.json"
 }


### PR DESCRIPTION
This is *a* solution to the problem I realized/described [earlier today](https://github.com/jinyus/related_post_gen/pull/430#issuecomment-1811611857).

Advantages
* Having `"json-type-provider"` as a dep in `info.rkt` isn't a problem — `raco pkg install` won't be slow nor will it exit with error
* Typed Racket impl is runnable in the container, though still not included in `all` because of the slow writes
* Don't have to change anything else
* It becomes very unlikely that adding module dep/s for the Racket or Typed Racket impls (if they're to be runnable in the container) will also involve installing "missing pieces" via `pacman` and/or `raco` during `docker build`.

Disadvantages
* The size of the container increases by several hundred MB (but not a lot in the grand scheme of things).

Feel free to close this PR if it's not the solution you want, and I'll do another PR splitting the `racket` dir into `racket` and `typed_racket`, no problem.