### PR TITLE
[Typed Racket] isolate write-json in an Optional Typed Racket submodule

### DIFF
--- a/racket/typed/related.rkt
+++ b/racket/typed/related.rkt
@@ -6,9 +6,9 @@
 (require/typed racket/base
                [current-inexact-monotonic-milliseconds (-> Real)])
 
-(define N : Positive-Integer 5)
-(define N-1 (- N 1))
-(define N-2 (- N 2))
+(define N : Exact-Positive-Integer 5)
+(define N-1 : Exact-Nonnegative-Integer (- N 1))
+(define N-2 : Integer (- N 2))
 
 (define-json-types
   [jspost ([_id : String] [title : String] [tags : (Listof String)])]
@@ -17,14 +17,14 @@
 (define-type JSPost jspost)
 (define-type Post post)
 (define-type Posts (Listof Post))
-(define-type PostIndex Integer)
+(define-type PostIndex Exact-Nonnegative-Integer)
 (define-type PostIndices (Listof PostIndex))
-(define-type RelatedCounts (Vectorof Integer))
+(define-type RelatedCounts (Vectorof Exact-Nonnegative-Integer))
 (define-type RelatedPosts related-posts)
 (define-type Tag Symbol)
 (define-type Tags (Listof Tag))
 (define-type TagMap (HashTable Tag PostIndices))
-(define-type VecLen Integer)
+(define-type VecLen Exact-Nonnegative-Integer)
 (define-type VecPosts (Vectorof Post))
 (define-type VecRelatedPosts (Vectorof RelatedPosts))
 
@@ -55,7 +55,7 @@
 (: make-tag-map (-> VecPosts TagMap))
 (define (make-tag-map posts)
   (let ([tag-map : TagMap (make-hasheq)])
-    (for* ([index (in-range (vector-length posts))]
+    (for* ([index : PostIndex (in-range (vector-length posts))]
            [tag (in-list (post-tags (vector-ref posts index)))])
       (hash-update! tag-map
                     tag
@@ -81,7 +81,7 @@
 
 (: tally (-> TagMap Post PostIndex VecLen RelatedCounts))
 (define (tally tag-map post index posts-len)
-  (let ([counts (make-vector posts-len 0)])
+  (let ([counts : RelatedCounts (make-vector posts-len 0)])
     (for* ([tag (in-list (post-tags post))]
            [related-index (in-list (hash-ref tag-map tag))])
       (vector-set! counts
@@ -125,7 +125,7 @@
         [tag-map (make-tag-map posts)])
     (for/vector : VecRelatedPosts
                 #:length posts-len
-                ([index (in-range posts-len)])
+                ([index : PostIndex (in-range posts-len)])
       (let* ([post (vector-ref posts index)]
              [counts (tally tag-map post index posts-len)])
         (related-posts (post-_id post)

--- a/run.sh
+++ b/run.sh
@@ -1116,7 +1116,7 @@ elif [ "$first_arg" = "racket" ]; then
 
     run_racket
 
-elif [ "$first_arg" = "typed/racket" ]; then
+elif [ "$first_arg" = "typed_racket" ]; then
 
     run_typed_racket
 

--- a/run.sh
+++ b/run.sh
@@ -1183,6 +1183,7 @@ elif [ "$first_arg" = "all" ]; then
         # run_ruby || echo -e "\n" && # too slow
         # run_dascript || echo -e "\n" && #not installed in docker
         run_racket || echo -e "\n" &&
+        run_typed_racket || echo -e "\n" &&
         run_lobster_jit || echo -e "\n" &&
         run_lobster_cpp || echo -e "\n" &&
         run_scala_native || echo -e "\n" &&


### PR DESCRIPTION
I made an effort to understand *[Shallow and Optional Typed Racket](https://blog.racket-lang.org/2022/11/shallow-typed-racket.html)* and applied what I learned to the Typed Racket impl.

With the changes in e98148f I'm essentially telling the toolchain:
* Enforce static typing
* Don't do deep runtime checking for `write-json`

So, across the board, we're still getting more (type) safety than in the untyped Racket impl (else why bother with Typed Racket), but for the serialization step we're relaxing the additional runtime-soundness that comes with (Deep/default) Typed Racket, while not doing *less* "safety stuff" at runtime than untyped Racket does anyway.

I added `run_typed_racket` to `all` in run.sh since serialization is no longer a big drag on `./run.sh typed/racket`.

The extensive `(provide ...)` I added anticipates a PR re: `racket/typed/related_con.rkt` and similar will be added in `racket/related.rkt` to support a PR for `racket/related_con.rkt`.

NOTE: a better approach re: `write-json` will be to implement a `Writer` to complement the `Reader` in [`json-type-provider`](https://github.com/philnguyen/json-type-provider)... I might get to it over the holidays, we'll see. 🎅