### PR TITLE
[Go] Zero out the slice at the end of the hot loop

### DIFF
--- a/go/main.go
+++ b/go/main.go
@@ -52,10 +52,6 @@ func main() {
 	taggedPostCount := make([]byte, postsLen)
 
 	for i := range posts {
-		for j := range taggedPostCount {
-			taggedPostCount[j] = 0
-		}
-
 		// Count the number of tags shared between posts
 		for _, tag := range posts[i].Tags {
 			for _, otherPostIdx := range tagMap[tag] {
@@ -97,6 +93,10 @@ func main() {
 			ID:      posts[i].ID,
 			Tags:    &posts[i].Tags,
 			Related: topPosts,
+		}
+
+		for j := range taggedPostCount {
+			taggedPostCount[j] = 0
 		}
 	}
 


### PR DESCRIPTION
Slower somehow. Ran 3 times with same results...

Main: `21.92 ms | 309.41 ms | 2.72 s `

This PR:
```
Go:

        Benchmark 1: ./related
        Processing time (w/o IO): 24.340213ms
        Processing time (w/o IO): 23.748908ms
        Processing time (w/o IO): 23.278704ms
        Processing time (w/o IO): 23.285804ms
        Processing time (w/o IO): 23.483405ms
        Processing time (w/o IO): 23.286104ms
        Processing time (w/o IO): 23.353805ms
        Processing time (w/o IO): 25.198021ms
        Processing time (w/o IO): 23.526606ms
        Processing time (w/o IO): 23.281704ms
        Processing time (w/o IO): 23.440705ms
        Processing time (w/o IO): 23.411605ms
        Processing time (w/o IO): 23.232303ms
          Time (mean ± σ):      62.8 ms ±   0.6 ms    [User: 64.0 ms, System: 6.6 ms]
          Range (min … max):    61.8 ms …  63.4 ms    10 runs
         
Go:

        Benchmark 1: ./related
        Processing time (w/o IO): 338.280961ms
        Processing time (w/o IO): 338.819666ms
        Processing time (w/o IO): 336.747348ms
          Time (mean ± σ):     476.3 ms ±   6.0 ms    [User: 475.6 ms, System: 25.4 ms]
          Range (min … max):   472.1 ms … 480.5 ms    2 runs
         
Go:

        Benchmark 1: ./related
        Processing time (w/o IO): 2.993567661s
        Processing time (w/o IO): 2.997847963s
        Processing time (w/o IO): 2.994174456s
          Time (mean ± σ):      3.480 s ±  0.001 s    [User: 3.486 s, System: 0.121 s]
          Range (min … max):    3.479 s …  3.481 s    2 runs

```

Fresh run on main:
```
Go:

        Benchmark 1: ./related
        Processing time (w/o IO): 21.745388ms
        Processing time (w/o IO): 21.730787ms
        Processing time (w/o IO): 21.574586ms
        Processing time (w/o IO): 22.063891ms
        Processing time (w/o IO): 21.799989ms
        Processing time (w/o IO): 21.769788ms
        Processing time (w/o IO): 21.772689ms
        Processing time (w/o IO): 21.738888ms
        Processing time (w/o IO): 21.547686ms
        Processing time (w/o IO): 23.000219ms
        Processing time (w/o IO): 21.729507ms
        Processing time (w/o IO): 21.823408ms
        Processing time (w/o IO): 21.760507ms
          Time (mean ± σ):      60.6 ms ±   1.0 ms    [User: 59.7 ms, System: 8.3 ms]
          Range (min … max):    59.3 ms …  62.8 ms    10 runs
         
Go:

        Benchmark 1: ./related
        Processing time (w/o IO): 312.485776ms
        Processing time (w/o IO): 310.136754ms
        Processing time (w/o IO): 313.464885ms
          Time (mean ± σ):     456.1 ms ±   3.1 ms    [User: 446.2 ms, System: 35.7 ms]
          Range (min … max):   454.0 ms … 458.3 ms    2 runs
         
Go:

        Benchmark 1: ./related
        Processing time (w/o IO): 2.729331094s
        Processing time (w/o IO): 2.731242328s
        Processing time (w/o IO): 2.731730441s
          Time (mean ± σ):      3.199 s ±  0.001 s    [User: 3.219 s, System: 0.098 s]
          Range (min … max):    3.199 s …  3.200 s    2 runs
```