### PR TITLE
[Nim] revise and speedup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ FROM archlinux:base
 # Update package repository
 RUN pacman -Syu --noconfirm
 
-RUN pacman -S --noconfirm --needed wget unzip sudo base-devel git clang llvm python python-pip ncurses gcc hyperfine rustup crystal zig dart nodejs deno maven nim opam dune lua51 luajit luarocks libedit github-cli less r
+RUN pacman -S --noconfirm --needed wget unzip sudo base-devel git clang llvm python python-pip ncurses gcc hyperfine rustup crystal zig dart nodejs deno maven opam dune lua51 luajit luarocks libedit github-cli less r
 
 # user needed to install aur packages
 RUN useradd -ms /bin/bash builduser
@@ -71,7 +71,10 @@ RUN ln -s /usr/lib/libncursesw.so.6 /usr/lib/libncurses.so.6
 
 RUN chmod +x /home/builduser/odin/odin && odin version && v version && swift --version && java --version
 
-# for nim
+# nim : commit 39fbd30.. on devel, 17 Nov 2023
+# https://github.com/nim-lang/Nim/tree/39fbd30
+RUN export CHOOSENIM_CHOOSE_VERSION=\#39fbd30; export CHOOSENIM_NO_ANALYTICS=1; curl https://nim-lang.org/choosenim/init.sh -sSf | bash -s -- -y
+ENV PATH="$PATH:/root/.nimble/bin"
 RUN cp /usr/lib/LLVMgold.so /home/builduser/swift-5.9-RELEASE-ubuntu22.04/usr/lib/LLVMgold.so
 
 # install julia

--- a/nim/related.nimble
+++ b/nim/related.nimble
@@ -11,6 +11,7 @@ bin           = @["related"]
 # Dependencies
 
 requires "nim >= 2.0.0"
+requires "decimal#head"
 requires "jsony#head"
 requires "xxhash"
 

--- a/nim/src/related.nim
+++ b/nim/src/related.nim
@@ -12,7 +12,7 @@ type
   RelatedPosts = object
     `"_id"`: string
     tags : ptr seq[string]
-    related: array[N, ptr Post]
+    related: array[N, Post]
 
 const
   input = "../posts.json"
@@ -64,7 +64,7 @@ proc findTopN(
     taggedPostCount: var seq[uint8],
     posts: seq[Post],
     topN: var array[N, tuple[idx: int, count: uint8]],
-    related: var array[N, ptr Post]) =
+    related: var array[N, Post]) =
   var minCount = 0'u8
   for i, count in taggedPostCount:
     if count > minCount:
@@ -80,7 +80,7 @@ proc findTopN(
       topN[pos].idx = i
       minCount = topN[N-1].count
   for i in 0..<N:
-    related[i] = addr posts[topN[i].idx]
+    related[i] = posts[topN[i].idx]
     topN[i].idx = 0
     topN[i].count = 0
 

--- a/nim/src/related.nim
+++ b/nim/src/related.nim
@@ -59,6 +59,8 @@ proc findTopN(
   var
     minCount = 0
     topN: array[N*2, int]
+  # counts for related posts in even indices of topN
+  # indices of related posts in odd indices of topN
   for i, count in taggedPostCount:
     let count = count.int
     if count > minCount:

--- a/nim/src/related.nim
+++ b/nim/src/related.nim
@@ -39,10 +39,10 @@ proc writePosts(path: string, posts: seq[RelatedPosts]) =
 {.push inline.}
 
 proc countTaggedPost(
-    taggedPostCount: var seq[uint8],
     posts: seq[Post],
     tagMap: Table[string, seq[int]],
-    i: int) =
+    i: int): seq[uint8] =
+  var taggedPostCount = newSeq[uint8](posts.len)
   for tag in posts[i].tags[]:
     try:
       for relatedIDX in tagMap[tag]:
@@ -50,11 +50,11 @@ proc countTaggedPost(
     except KeyError as e:
       raise (ref Defect)(msg: e.msg)
   taggedPostCount[i] = 0 # remove self
+  taggedPostCount
 
 proc findTopN(
     taggedPostCount: var seq[uint8],
     posts: seq[Post],
-    # topN: var array[N*2, int],
     related: var array[N, Post]) =
   var topN: array[N*2, int]
   var minCount = 0
@@ -81,13 +81,9 @@ proc process(
     tagMap: Table[string, seq[int]],
     relatedPosts: var seq[RelatedPosts]) =
   for i in 0..<posts.len:
-    var
-      taggedPostCount = newSeq[uint8](posts.len)
-      # topN: array[N*2, int]
-    taggedPostCount.countTaggedPost(posts, tagMap, i)
+    var taggedPostCount = countTaggedPost(posts, tagMap, i)
     relatedPosts[i].`"_id"` = posts[i].`"_id"`
     relatedPosts[i].tags = posts[i].tags
-    # taggedPostCount.findTopN(posts, topN, relatedPosts[i].related)
     taggedPostCount.findTopN(posts, relatedPosts[i].related)
 
 {.pop.}

--- a/nim/src/related.nim
+++ b/nim/src/related.nim
@@ -53,7 +53,7 @@ proc countTaggedPost(
   for tag in posts[i].tags:
     try:
       for relatedIDX in tagMap[tag]:
-        inc(taggedPostCount[relatedIDX])
+        inc taggedPostCount[relatedIDX]
     except KeyError as e:
       raise (ref Defect)(msg: e.msg)
   taggedPostCount[i] = 0 # remove self
@@ -63,14 +63,21 @@ proc findTop5(
     posts: seq[Post],
     top5: var array[5, tuple[idx: int, count: uint8]],
     related: var array[5, ptr Post]) =
+  var minCount = 0'u8
   for i, count in taggedPostCount:
-    if count > top5[4].count:
-      top5[4].idx = i
-      top5[4].count = count
-      for pos in countdown(3, 0):
-        if count > top5[pos].count:
-          swap(top5[pos+1], top5[pos])
-  for i in 0..<top5.len:
+    if count > minCount:
+      var pos = 3
+      while (pos >= 0) and (count > top5[pos].count):
+        dec pos
+      inc pos
+      if pos < 4:
+        for j in countdown(3, pos):
+          top5[j+1].count = top5[j].count
+          top5[j+1].idx = top5[j].idx
+      top5[pos].count = count
+      top5[pos].idx = i
+      minCount = top5[4].count
+  for i in 0..<5:
     related[i] = addr posts[top5[i].idx]
     top5[i].idx = 0
     top5[i].count = 0

--- a/nim/src/related.nim
+++ b/nim/src/related.nim
@@ -7,11 +7,11 @@ type
   Post = ref object
     `"_id"`: string
     title: string
-    tags : seq[string]
+    tags : ref seq[string]
 
   RelatedPosts = object
     `"_id"`: string
-    tags : ptr seq[string]
+    tags : ref seq[string]
     related: array[N, Post]
 
 const
@@ -24,16 +24,10 @@ func hash(x: string): Hash {.inline, used.} =
 func `[]`(t: Table[string, seq[int]], key: string): lent seq[int] =
   tables.`[]`(t.addr[], key)
 
-proc dumpHook(s: var string, v: ptr) {.inline, used.} =
-  if v == nil:
-    s.add("null")
-  else:
-    s.dumpHook(v[])
-
 func genTagMap(posts: seq[Post]): Table[string, seq[int]] =
   result = initTable[string, seq[int]](100)
   for i, post in posts:
-    for tag in post.tags:
+    for tag in post.tags[]:
       result.withValue(tag, val):
         val[].add i
       do:
@@ -52,7 +46,7 @@ proc countTaggedPost(
     posts: seq[Post],
     tagMap: Table[string, seq[int]],
     i: int) =
-  for tag in posts[i].tags:
+  for tag in posts[i].tags[]:
     try:
       for relatedIDX in tagMap[tag]:
         inc taggedPostCount[relatedIDX]
@@ -93,7 +87,7 @@ proc process(
     var taggedPostCount = newSeq[uint8](posts.len)
     taggedPostCount.countTaggedPost(posts, tagMap, i)
     relatedPosts[i].`"_id"` = posts[i].`"_id"`
-    relatedPosts[i].tags = addr posts[i].tags
+    relatedPosts[i].tags = posts[i].tags
     taggedPostCount.findTopN(posts, topN, relatedPosts[i].related)
 
 {.pop.}

--- a/nim/src/related.nim
+++ b/nim/src/related.nim
@@ -53,8 +53,7 @@ proc countTaggedPost(
 
 proc findTopN(
     taggedPostCount: var seq[uint8],
-    posts: seq[Post],
-    related: var array[N, Post]) =
+    posts: seq[Post]): array[N, Post] =
   var topN: array[N*2, int]
   var minCount = 0
   for i, count in taggedPostCount:
@@ -72,8 +71,7 @@ proc findTopN(
       topN[pos+1] = i
       minCount = topN[(N-1)*2]
   for i in 0..<N:
-    let j = i*2
-    related[i] = posts[topN[j+1]]
+    result[i] = posts[topN[i*2+1]]
 
 proc process(
     posts: seq[Post],
@@ -83,7 +81,7 @@ proc process(
     var taggedPostCount = countTaggedPost(posts, tagMap, i)
     relatedPosts[i].`"_id"` = posts[i].`"_id"`
     relatedPosts[i].tags = posts[i].tags
-    taggedPostCount.findTopN(posts, relatedPosts[i].related)
+    relatedPosts[i].related = findTopN(taggedPostCount, posts)
 
 {.pop.}
 

--- a/nim/src/related.nim
+++ b/nim/src/related.nim
@@ -21,9 +21,6 @@ const
 func hash(x: string): Hash {.inline, used.} =
   cast[Hash](XXH3_64bits(x))
 
-func `[]`(t: Table[string, seq[int]], key: string): lent seq[int] =
-  tables.`[]`(t.addr[], key)
-
 func genTagMap(posts: seq[Post]): Table[string, seq[int]] =
   result = initTable[string, seq[int]](100)
   for i, post in posts:

--- a/nim/src/related.nim
+++ b/nim/src/related.nim
@@ -52,10 +52,13 @@ proc countTaggedPost(
   result[i] = 0 # remove self
 
 proc findTopN(
-    taggedPostCount: var seq[uint8],
-    posts: seq[Post]): array[N, Post] =
-  var topN: array[N*2, int]
-  var minCount = 0
+    posts: seq[Post],
+    tagMap: Table[string, seq[int]],
+    i: int): array[N, Post] =
+  let taggedPostCount = countTaggedPost(posts, tagMap, i)
+  var
+    minCount = 0
+    topN: array[N*2, int]
   for i, count in taggedPostCount:
     let count = count.int
     if count > minCount:
@@ -78,10 +81,9 @@ proc process(
     tagMap: Table[string, seq[int]],
     relatedPosts: var seq[RelatedPosts]) =
   for i in 0..<posts.len:
-    var taggedPostCount = countTaggedPost(posts, tagMap, i)
     relatedPosts[i].`"_id"` = posts[i].`"_id"`
     relatedPosts[i].tags = posts[i].tags
-    relatedPosts[i].related = findTopN(taggedPostCount, posts)
+    relatedPosts[i].related = posts.findTopN(tagMap, i)
 
 {.pop.}
 

--- a/nim/src/related.nim
+++ b/nim/src/related.nim
@@ -54,8 +54,9 @@ proc countTaggedPost(
 proc findTopN(
     taggedPostCount: var seq[uint8],
     posts: seq[Post],
-    topN: var array[N*2, int],
+    # topN: var array[N*2, int],
     related: var array[N, Post]) =
+  var topN: array[N*2, int]
   var minCount = 0
   for i, count in taggedPostCount:
     let count = count.int
@@ -82,11 +83,12 @@ proc process(
   for i in 0..<posts.len:
     var
       taggedPostCount = newSeq[uint8](posts.len)
-      topN: array[N*2, int]
+      # topN: array[N*2, int]
     taggedPostCount.countTaggedPost(posts, tagMap, i)
     relatedPosts[i].`"_id"` = posts[i].`"_id"`
     relatedPosts[i].tags = posts[i].tags
-    taggedPostCount.findTopN(posts, topN, relatedPosts[i].related)
+    # taggedPostCount.findTopN(posts, topN, relatedPosts[i].related)
+    taggedPostCount.findTopN(posts, relatedPosts[i].related)
 
 {.pop.}
 

--- a/nim/src/related.nim
+++ b/nim/src/related.nim
@@ -49,7 +49,7 @@ proc writePosts(path: string, posts: seq[RelatedPosts]) =
 
 {.push inline.}
 
-proc countTaggedPost(
+func countTaggedPost(
     posts: seq[Post],
     tagMap: Table[string, seq[int]],
     i: int): seq[uint8] =
@@ -62,7 +62,7 @@ proc countTaggedPost(
       raise (ref Defect)(msg: e.msg)
   result[i] = 0 # remove self
 
-proc findTopN(
+func findTopN(
     posts: seq[Post],
     tagMap: Table[string, seq[int]],
     i: int): array[N, Post] =
@@ -89,7 +89,7 @@ proc findTopN(
   for i in 0..<N:
     result[i] = posts[topN[i*2+1]]
 
-proc process(posts: seq[Post]): seq[RelatedPosts] =
+func process(posts: seq[Post]): seq[RelatedPosts] =
   let tagMap = posts.genTagMap
   # collect(newSeqOfCap(posts.len)):
   collect:

--- a/nim/src/related.nim
+++ b/nim/src/related.nim
@@ -1,6 +1,17 @@
 import std/[hashes, monotimes, sugar, tables, times]
 import pkg/[decimal, jsony, xxhash]
 
+# questions re: performance in Azure VM/Docker
+# --------------------------------------------
+# ? is returning seq from findTopN faster than returning array
+# ? is `collect(newSeqOfCap(posts.len)):` faster than `collect:`
+# ? is `object` or `ref object` faster re: `type RelatedPosts`
+# ? is it faster with or without inlining hints
+# ? how to correctly round DecimalType to 2 places
+
+# ^ unfortunately, the answers to some questions (and what combination of
+# changes is overall fastest) can depend on choice of clang vs. gcc
+
 const N: Positive = 5
 
 type

--- a/nim/src/related.nim
+++ b/nim/src/related.nim
@@ -42,15 +42,14 @@ proc countTaggedPost(
     posts: seq[Post],
     tagMap: Table[string, seq[int]],
     i: int): seq[uint8] =
-  var taggedPostCount = newSeq[uint8](posts.len)
+  result = newSeq[uint8](posts.len)
   for tag in posts[i].tags[]:
     try:
       for relatedIDX in tagMap[tag]:
-        inc taggedPostCount[relatedIDX]
+        inc result[relatedIDX]
     except KeyError as e:
       raise (ref Defect)(msg: e.msg)
-  taggedPostCount[i] = 0 # remove self
-  taggedPostCount
+  result[i] = 0 # remove self
 
 proc findTopN(
     taggedPostCount: var seq[uint8],

--- a/nim/src/related.nim
+++ b/nim/src/related.nim
@@ -3,7 +3,6 @@ import pkg/[decimal, jsony, xxhash]
 
 # questions re: performance in Azure VM/Docker
 # --------------------------------------------
-# ? is returning seq from findTopN faster than returning array
 # ? how to correctly round DecimalType to 2 places
 
 const N: Positive = 5

--- a/nim/src/related.nim
+++ b/nim/src/related.nim
@@ -31,6 +31,14 @@ proc dumpHook(s: var string, v: ptr) {.inline, used.} =
   else:
     s.dumpHook(v[])
 
+proc readPosts(path: string): seq[Post] =
+  path.readFile.fromJson(seq[Post])
+
+proc writePosts(path: string, posts: seq[RelatedPosts]) =
+  path.writeFile(posts.toJson)
+
+{.push inline.}
+
 func genTagMap(posts: seq[Post]): Table[string, seq[int]] =
   result = initTable[string, seq[int]](100)
   for i, post in posts:
@@ -39,14 +47,6 @@ func genTagMap(posts: seq[Post]): Table[string, seq[int]] =
         val[].add i
       do:
         result[tag] = @[i]
-
-proc readPosts(path: string): seq[Post] =
-  path.readFile.fromJson(seq[Post])
-
-proc writePosts(path: string, posts: seq[RelatedPosts]) =
-  path.writeFile(posts.toJson)
-
-{.push inline.}
 
 func countTaggedPost(
     posts: seq[Post],

--- a/nim/src/related.nim
+++ b/nim/src/related.nim
@@ -17,7 +17,7 @@ type
   RelatedPosts = ref object
     `"_id"`: string
     tags : ref seq[string]
-    related: array[N, Post]
+    related: array[N, ptr Post]
 
 const
   input = "../posts.json"
@@ -25,6 +25,12 @@ const
 
 func hash(x: string): Hash {.inline, used.} =
   cast[Hash](XXH3_64bits(x))
+
+proc dumpHook(s: var string, v: ptr) {.inline, used.} =
+  if v == nil:
+    s.add("null")
+  else:
+    s.dumpHook(v[])
 
 func genTagMap(posts: seq[Post]): Table[string, seq[int]] =
   result = initTable[string, seq[int]](100)
@@ -59,7 +65,7 @@ func countTaggedPost(
 func findTopN(
     posts: seq[Post],
     tagMap: Table[string, seq[int]],
-    i: int): array[N, Post] =
+    i: int): array[N, ptr Post] =
   let taggedPostCount = countTaggedPost(posts, tagMap, i)
   var
     minCount = 0
@@ -81,7 +87,7 @@ func findTopN(
       topN[pos+1] = i
       minCount = topN[(N-1)*2]
   for i in 0..<N:
-    result[i] = posts[topN[i*2+1]]
+    result[i] = addr posts[topN[i*2+1]]
 
 func process(posts: seq[Post]): seq[RelatedPosts] =
   let tagMap = posts.genTagMap

--- a/nim/src/related.nim
+++ b/nim/src/related.nim
@@ -5,7 +5,6 @@ import pkg/[decimal, jsony, xxhash]
 # --------------------------------------------
 # ? is returning seq from findTopN faster than returning array
 # ? is `collect(newSeqOfCap(posts.len)):` faster than `collect:`
-# ? is `object` or `ref object` faster re: `type RelatedPosts`
 # ? is it faster with or without inlining hints
 # ? how to correctly round DecimalType to 2 places
 
@@ -20,7 +19,7 @@ type
     title: string
     tags : ref seq[string]
 
-  RelatedPosts = object
+  RelatedPosts = ref object
     `"_id"`: string
     tags : ref seq[string]
     related: array[N, Post]

--- a/nim/src/related.nim
+++ b/nim/src/related.nim
@@ -5,11 +5,7 @@ import pkg/[decimal, jsony, xxhash]
 # --------------------------------------------
 # ? is returning seq from findTopN faster than returning array
 # ? is `collect(newSeqOfCap(posts.len)):` faster than `collect:`
-# ? is it faster with or without inlining hints
 # ? how to correctly round DecimalType to 2 places
-
-# ^ unfortunately, the answers to some questions (and what combination of
-# changes is overall fastest) can depend on choice of clang vs. gcc
 
 const N: Positive = 5
 

--- a/nim/src/related.nim
+++ b/nim/src/related.nim
@@ -1,10 +1,6 @@
 import std/[hashes, monotimes, sugar, tables, times]
 import pkg/[decimal, jsony, xxhash]
 
-# questions re: performance in Azure VM/Docker
-# --------------------------------------------
-# ? how to correctly round DecimalType to 2 places
-
 const N: Positive = 5
 
 type
@@ -107,8 +103,11 @@ proc main() =
     t1 = getMonotime()
     timeNs: int64 = (t1 - t0).inNanoseconds
     timeMs: DecimalType = newDecimal(timeNs) / newDecimal(1_000_000)
+    timeMsS = $timeMs
+  setPrec(4)
+  let time = newDecimal(timeMsS)
   output.writePosts(relatedPosts)
-  echo "Processing time (w/o IO): ", timeMs, "ms"
+  echo "Processing time (w/o IO): ", time, "ms"
 
 when isMainModule:
   main()

--- a/nim/src/related.nim
+++ b/nim/src/related.nim
@@ -22,10 +22,10 @@ const
   input = "../posts.json"
   output = "../related_posts_nim.json"
 
-func hash(x: string): Hash {.inline, used.} =
+func hash(x: string): Hash {.inline.} =
   cast[Hash](XXH3_64bits(x))
 
-func dumpHook(s: var string, v: ptr) {.inline, used.} =
+func dumpHook(s: var string, v: ptr) {.inline.} =
   if v == nil:
     s.add("null")
   else:

--- a/nim/src/related.nim
+++ b/nim/src/related.nim
@@ -74,16 +74,15 @@ proc findTopN(
   for i in 0..<N:
     let j = i*2
     related[i] = posts[topN[j+1]]
-    topN[j] = 0
-    topN[j+1] = 0
 
 proc process(
     posts: seq[Post],
     tagMap: Table[string, seq[int]],
     relatedPosts: var seq[RelatedPosts]) =
-  var topN: array[N*2, int]
   for i in 0..<posts.len:
-    var taggedPostCount = newSeq[uint8](posts.len)
+    var
+      taggedPostCount = newSeq[uint8](posts.len)
+      topN: array[N*2, int]
     taggedPostCount.countTaggedPost(posts, tagMap, i)
     relatedPosts[i].`"_id"` = posts[i].`"_id"`
     relatedPosts[i].tags = posts[i].tags

--- a/nim/src/related.nim
+++ b/nim/src/related.nim
@@ -78,8 +78,8 @@ proc findTopN(
 
 proc process(
     posts: seq[Post],
-    tagMap: Table[string, seq[int]],
     relatedPosts: var seq[RelatedPosts]) =
+  let tagMap = genTagMap(posts)
   for i in 0..<posts.len:
     relatedPosts[i].`"_id"` = posts[i].`"_id"`
     relatedPosts[i].tags = posts[i].tags
@@ -91,9 +91,8 @@ proc main() =
   let
     posts = input.readPosts
     t0 = getMonotime()
-    tagMap = genTagMap(posts)
   var relatedPosts = newSeq[RelatedPosts](posts.len)
-  posts.process(tagMap, relatedPosts)
+  posts.process(relatedPosts)
   let time = (getMonotime() - t0).inMicroseconds / 1000
   output.writePosts(relatedPosts)
   echo "Processing time (w/o IO): ", time, "ms"

--- a/nim/src/related.nim
+++ b/nim/src/related.nim
@@ -25,7 +25,7 @@ const
 func hash(x: string): Hash {.inline, used.} =
   cast[Hash](XXH3_64bits(x))
 
-proc dumpHook(s: var string, v: ptr) {.inline, used.} =
+func dumpHook(s: var string, v: ptr) {.inline, used.} =
   if v == nil:
     s.add("null")
   else:

--- a/nim/src/related.nim
+++ b/nim/src/related.nim
@@ -4,7 +4,6 @@ import pkg/[decimal, jsony, xxhash]
 # questions re: performance in Azure VM/Docker
 # --------------------------------------------
 # ? is returning seq from findTopN faster than returning array
-# ? is `collect(newSeqOfCap(posts.len)):` faster than `collect:`
 # ? how to correctly round DecimalType to 2 places
 
 const N: Positive = 5
@@ -86,7 +85,6 @@ func findTopN(
 
 func process(posts: seq[Post]): seq[RelatedPosts] =
   let tagMap = posts.genTagMap
-  # collect(newSeqOfCap(posts.len)):
   collect:
     for i, post in posts:
       RelatedPosts(


### PR DESCRIPTION
I saw the recent changes making use of a flattened list/slice and thought Nim might benefit from that as well. I also noticed the rule change in e68b47a.

The changes in this PR include building/installing the Nim compiler from its `devel` branch using [`choosenim`](https://github.com/dom96/choosenim). It's pinned to a specific commit in the Dockerfile, which can easily be updated in the future or replaced with a version such as `2.0.2` or `2.2.0` (whatever is the next stable release of v2).

With the upgraded Nim compiler, it was feasible to switch (back) to a return-values approach vs. mutating `var` parameters, with the performance being the same or a little better. Several other revisions flowed from that. 

While I was working on it, I noticed some flakiness re:
```nim
let time = (getMonotime() - t0).inMicroseconds / 1000
```
I won't elaborate unless you want details, but I found it puzzling/troubling, so I switched to using [nim-decimal](https://github.com/inv2004/nim-decimal) to compute rounded processing times derived from the `int64` values (nanoseconds) obtained from `getMonotime()`/`.inNanoseconds`. That seems to avoid whatever weirdness was happening with the floating point numbers, though I wish I understood the problem better because it may be a bug that needs to be reported.

I'll work on a complementary PR for `nim_con` another time.