### PR TITLE
common-lisp stack overflow fix

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -547,7 +547,7 @@ run_erlang() {
 run_common_lisp_sbcl() {
     echo "Running Common Lisp (SBCL)" &&
         cd ./common-lisp &&
-        sbcl --non-interactive --load related.lisp
+        sbcl --control-stack-size 10 --non-interactive --load related.lisp
         run_command "Common Lisp (SBCL)" $slow_lang_runs ./related &&
         check_output "related-cl.json"
 }


### PR DESCRIPTION
ok, it was easy. 
Looks like in new version of SBCL, also with type optimization from last commit, some data start keeping in stack (from heap), so we got stack overflow. By default it is only 2mb, now it is 10 mb