### PR TITLE
clojure: limit jvm warmup phase

### DIFF
--- a/clojure/src/related/core.clj
+++ b/clojure/src/related/core.clj
@@ -85,7 +85,8 @@
                                                    (class (make-array Post 0)))
 
           ;; warmup
-          _ (do (get-all-related-posts posts)
+          _ (do (get-all-related-posts
+                 (java.util.Arrays/copyOfRange posts 0 (min 5000 (alength posts))))
                 (System/gc))
           ;; ------
 


### PR DESCRIPTION
this one limits the warmup phase to 5000 posts, decreasing total run time

as an interesting consequence it also slightly speeds up larger data processing (at least on my machine)