### PR TITLE
Ruby: uglier but faster implementation

### DIFF
--- a/ruby/related.rb
+++ b/ruby/related.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'json'
 require 'time'
 
@@ -7,24 +9,46 @@ posts = JSON.parse(File.read('../posts.json'), symbolize_names: true)
 
 t1 = Time.now
 
+POST_SIZE = posts.length
 tag_map = Hash.new { |hash, key| hash[key] = [] }
 
-posts.each_with_index do |post, i|
-  post[:tags].each do |tag|
-    tag_map[tag] << i
+i = 0
+while i < POST_SIZE
+  tags = posts[i][:tags]
+  tag_size = tags&.length.to_i
+
+  j = 0
+  while j < tag_size
+    tag_map[tags[j]] << i
+    j += 1
   end
+
+  i += 1
 end
 
-all_related_posts = Array.new(posts.size)
-tagged_post_count = Array.new(posts.size, 0)
+all_related_posts = Array.new(POST_SIZE)
+tagged_post_count = Array.new(POST_SIZE, 0)
 
-posts.each_with_index do |post, idx|
+idx = 0
+while idx < POST_SIZE
+  post = posts[idx]
+  tags = post[:tags]
+
   tagged_post_count.fill(0)
 
-  post[:tags].each do |tag|
-    tag_map[tag].each do |oidx|
-      tagged_post_count[oidx] += 1
+  ti = 0
+  while ti < tags.length
+    tag = tags[ti]
+    o = tag_map[tag]
+
+    tj = 0
+    while tj < o.length
+      tagged_post_count[o[tj]] += 1
+      tj += 1
     end
+    tag_map[tag]
+
+    ti += 1
   end
 
   tagged_post_count[idx] = 0
@@ -33,7 +57,9 @@ posts.each_with_index do |post, idx|
   top_posts = Array.new(TOPN)
   min_tags = 0
 
-  tagged_post_count.each_with_index do |count, j|
+  j = 0
+  while j < tagged_post_count.length
+    count = tagged_post_count[j]
     if count > min_tags
       upper_bound = (TOPN - 2)
 
@@ -49,9 +75,11 @@ posts.each_with_index do |post, idx|
 
       min_tags = top5[TOPN - 1]
     end
+    j += 1
   end
 
-  all_related_posts[idx] = {_id: post[:_id],tags: post[:tags], related: top_posts}
+  all_related_posts[idx] = {_id: post[:_id], tags: tags, related: top_posts}
+  idx += 1
 end
 
 t2 = Time.now

--- a/ruby/related.rb
+++ b/ruby/related.rb
@@ -46,7 +46,6 @@ while idx < POST_SIZE
       tagged_post_count[o[tj]] += 1
       tj += 1
     end
-    tag_map[tag]
 
     ti += 1
   end


### PR DESCRIPTION
Mostly I just replaced `.each` and `.each_with_index` with `while` loop, locally it performs almost two times faster. Looks ugly but performs better :upside_down_face: 
also performance can be improved by just enabling YJIT and using `Oj` gem instead of `JSON` from std

CPU: AMD Ryzen 7 4700U
RAM: 16 GiB
Ruby: 3.3.4

Old:
```
Running ruby
Ruby:

        Processing time (w/o IO): 2883ms
        total: 2.99s memory: 25684k
        Processing time (w/o IO): 3206ms
        total: 3.31s memory: 25492k
        Processing time (w/o IO): 2979ms
        total: 3.08s memory: 25616k
        Processing time (w/o IO): 2973ms
        total: 3.07s memory: 25756k
        Processing time (w/o IO): 3027ms
        total: 3.13s memory: 25448k
        Processing time (w/o IO): 2889ms
        total: 2.99s memory: 25872k
        Processing time (w/o IO): 2944ms
        total: 3.05s memory: 25700k
        Processing time (w/o IO): 2894ms
        total: 3.00s memory: 25816k
        Processing time (w/o IO): 2897ms
        total: 2.99s memory: 25496k
        Processing time (w/o IO): 3055ms
        total: 3.16s memory: 25876k
Checking output
Success: related_posts_ruby.json is valid!
```
New:
```
Running ruby
Ruby:

        Processing time (w/o IO): 1518ms
        total: 1.62s memory: 25532k
        Processing time (w/o IO): 1516ms
        total: 1.62s memory: 25516k
        Processing time (w/o IO): 1504ms
        total: 1.61s memory: 25476k
        Processing time (w/o IO): 1534ms
        total: 1.64s memory: 25464k
        Processing time (w/o IO): 1523ms
        total: 1.64s memory: 25328k
        Processing time (w/o IO): 1538ms
        total: 1.65s memory: 25548k
        Processing time (w/o IO): 1509ms
        total: 1.61s memory: 25536k
        Processing time (w/o IO): 1512ms
        total: 1.60s memory: 25508k
        Processing time (w/o IO): 1561ms
        total: 1.67s memory: 25376k
        Processing time (w/o IO): 1486ms
        total: 1.59s memory: 25456k
Checking output
Success: related_posts_ruby.json is valid!
```