### PR TITLE
Update Nim Dockerfile and results showing improved performance metrics

### DIFF
--- a/dockerfiles/nim.Dockerfile
+++ b/dockerfiles/nim.Dockerfile
@@ -1,7 +1,4 @@
-# nim : commit 39fbd30.. on devel, 17 Nov 2023
-# https://github.com/nim-lang/Nim/tree/39fbd30
-RUN export CHOOSENIM_CHOOSE_VERSION=\#39fbd30 && export CHOOSENIM_NO_ANALYTICS=1 && curl https://nim-lang.org/choosenim/init.sh -sSf | bash -s -- -y
-ENV PATH="$PATH:/root/.nimble/bin"
+RUN pacman -S --noconfirm --needed nim
 
 #precompile
 RUN git clone https://github.com/jinyus/related_post_gen.git /tmp/repo && cd /tmp/repo && ./run.sh nim

--- a/readme.md
+++ b/readme.md
@@ -80,11 +80,11 @@ docker run -e TEST_NAME=go -it --rm go_databench
 | C# (JIT) | 22.53 ms | 314.86 ms | 2.76 s | 3.10 s |
 | C# (AOT) | 21.48 ms | 318.20 ms | 2.79 s | 3.12 s |
 | Haskell | 26.65 ms | 347.84 ms | 2.81 s | 3.19 s |
+| Nim | 22.34 ms | 337.00 ms | 2.95 s | 3.31 s |
 | F# (JIT) | 25.02 ms | 354.38 ms | 3.02 s | 3.40 s |
 | Julia | 23.66 ms | 350.96 ms | 3.10 s | 3.47 s |
 | Vlang | 26.39 ms | 372.67 ms | 3.24 s | 3.64 s |
 | D | 29.92 ms | 413.98 ms | 3.60 s | 4.05 s |
-| Nim | 31.00 ms | 469.88 ms | 4.15 s | 4.65 s |
 | Swift | 36.61 ms | 482.22 ms | 4.19 s | 4.71 s |
 | F# (AOT) | 37.92 ms | 570.90 ms | 5.07 s | 5.68 s |
 | Java (GraalVM) | 33.30 ms | 504.00 ms | 5.47 s | 6.01 s |
@@ -120,8 +120,8 @@ docker run -e TEST_NAME=go -it --rm go_databench
 | C# Concurrent (AOT) | 5.27 ms | 60.57 ms | 487.37 ms | 553.22 ms |
 | D Concurrent | 8.84 ms | 76.34 ms | 560.38 ms | 645.56 ms |
 | Rust Concurrent | 5.43 ms | 69.22 ms | 602.36 ms | 677.00 ms |
+| Nim Concurrent | 6.17 ms | 90.26 ms | 657.74 ms | 754.17 ms |
 | Go Concurrent | 6.89 ms | 92.48 ms | 771.56 ms | 870.92 ms |
-| Nim Concurrent | 7.55 ms | 104.09 ms | 902.34 ms | 1.01 s |
 | F# Concurrent (AOT) | 8.40 ms | 114.00 ms | 1.00 s | 1.13 s |
 | F# Concurrent | 8.80 ms | 122.33 ms | 1.08 s | 1.21 s |
 | Swift Concurrent | 13.24 ms | 148.23 ms | 1.20 s | 1.37 s |

--- a/results/raw_results_nim.md
+++ b/results/raw_results_nim.md
@@ -1,41 +1,40 @@
+Nim:
+
+        Processing time (w/o IO): 22.39ms
+        total: 0.04s memory: 12928k
+        Processing time (w/o IO): 22.47ms
+        total: 0.04s memory: 12800k
+        Processing time (w/o IO): 22.22ms
+        total: 0.04s memory: 12800k
+        Processing time (w/o IO): 22.34ms
+        total: 0.04s memory: 12800k
+        Processing time (w/o IO): 22.27ms
+        total: 0.04s memory: 12928k
+        Processing time (w/o IO): 22.37ms
+        total: 0.04s memory: 12672k
+        Processing time (w/o IO): 22.27ms
+        total: 0.04s memory: 12800k
+        Processing time (w/o IO): 22.47ms
+        total: 0.04s memory: 12800k
+        Processing time (w/o IO): 22.31ms
+        total: 0.04s memory: 12928k
+        Processing time (w/o IO): 22.28ms
+        total: 0.04s memory: 12928k
 
 Nim:
 
-	Processing time (w/o IO): 30.80ms
-	total: 0.05s memory: 12800k
-	Processing time (w/o IO): 31.06ms
-	total: 0.05s memory: 12800k
-	Processing time (w/o IO): 30.99ms
-	total: 0.05s memory: 12800k
-	Processing time (w/o IO): 30.78ms
-	total: 0.05s memory: 12672k
-	Processing time (w/o IO): 30.91ms
-	total: 0.05s memory: 12928k
-	Processing time (w/o IO): 31.21ms
-	total: 0.05s memory: 12928k
-	Processing time (w/o IO): 31.01ms
-	total: 0.05s memory: 12800k
-	Processing time (w/o IO): 31.04ms
-	total: 0.05s memory: 12800k
-	Processing time (w/o IO): 31.25ms
-	total: 0.05s memory: 12672k
-	Processing time (w/o IO): 30.95ms
-	total: 0.05s memory: 12800k
+        Processing time (w/o IO): 337.69ms
+        total: 0.43s memory: 54784k
+        Processing time (w/o IO): 336.78ms
+        total: 0.44s memory: 54784k
+        Processing time (w/o IO): 336.54ms
+        total: 0.44s memory: 54784k
 
 Nim:
 
-	Processing time (w/o IO): 469.79ms
-	total: 0.57s memory: 54784k
-	Processing time (w/o IO): 471.38ms
-	total: 0.57s memory: 54784k
-	Processing time (w/o IO): 468.46ms
-	total: 0.57s memory: 54784k
-
-Nim:
-
-	Processing time (w/o IO): 4152.53ms
-	total: 4.50s memory: 176128k
-	Processing time (w/o IO): 4153.93ms
-	total: 4.54s memory: 176000k
-	Processing time (w/o IO): 4133.98ms
-	total: 4.50s memory: 176128k
+        Processing time (w/o IO): 2958.91ms
+        total: 3.34s memory: 176000k
+        Processing time (w/o IO): 2952.33ms
+        total: 3.32s memory: 176000k
+        Processing time (w/o IO): 2949.09ms
+        total: 3.55s memory: 176000k

--- a/results/raw_results_nim_con.md
+++ b/results/raw_results_nim_con.md
@@ -1,41 +1,40 @@
+Nim Concurrent:
+
+        Processing time (w/o IO): 6.363ms
+        total: 0.02s memory: 12800k
+        Processing time (w/o IO): 6.324ms
+        total: 0.03s memory: 16128k
+        Processing time (w/o IO): 5.957ms
+        total: 0.03s memory: 16128k
+        Processing time (w/o IO): 6.186ms
+        total: 0.03s memory: 12800k
+        Processing time (w/o IO): 6.232ms
+        total: 0.02s memory: 12800k
+        Processing time (w/o IO): 6.102ms
+        total: 0.02s memory: 12928k
+        Processing time (w/o IO): 6.228ms
+        total: 0.03s memory: 16896k
+        Processing time (w/o IO): 6.219ms
+        total: 0.02s memory: 12800k
+        Processing time (w/o IO): 5.954ms
+        total: 0.02s memory: 12800k
+        Processing time (w/o IO): 6.131ms
+        total: 0.02s memory: 12800k
 
 Nim Concurrent:
 
-	Processing time (w/o IO): 7.493ms
-	total: 0.02s memory: 12800k
-	Processing time (w/o IO): 7.51ms
-	total: 0.03s memory: 12928k
-	Processing time (w/o IO): 7.503ms
-	total: 0.02s memory: 12800k
-	Processing time (w/o IO): 7.537ms
-	total: 0.03s memory: 12800k
-	Processing time (w/o IO): 7.443ms
-	total: 0.03s memory: 16896k
-	Processing time (w/o IO): 7.842ms
-	total: 0.02s memory: 12800k
-	Processing time (w/o IO): 7.468ms
-	total: 0.02s memory: 12800k
-	Processing time (w/o IO): 7.603ms
-	total: 0.02s memory: 12800k
-	Processing time (w/o IO): 7.596ms
-	total: 0.02s memory: 12800k
-	Processing time (w/o IO): 7.475ms
-	total: 0.02s memory: 12800k
+        Processing time (w/o IO): 113.805ms
+        total: 0.21s memory: 53120k
+        Processing time (w/o IO): 78.59099999999999ms
+        total: 0.18s memory: 53376k
+        Processing time (w/o IO): 78.371ms
+        total: 0.18s memory: 53120k
 
 Nim Concurrent:
 
-	Processing time (w/o IO): 104.286ms
-	total: 0.20s memory: 53248k
-	Processing time (w/o IO): 104.412ms
-	total: 0.19s memory: 53376k
-	Processing time (w/o IO): 103.564ms
-	total: 0.20s memory: 53248k
-
-Nim Concurrent:
-
-	Processing time (w/o IO): 904.745ms
-	total: 1.27s memory: 169984k
-	Processing time (w/o IO): 897.074ms
-	total: 1.25s memory: 169600k
-	Processing time (w/o IO): 905.211ms
-	total: 1.27s memory: 169728k
+        Processing time (w/o IO): 657.631ms
+        total: 1.01s memory: 174592k
+        Processing time (w/o IO): 663.066ms
+        total: 1.01s memory: 174592k
+        Processing time (w/o IO): 652.527ms
+        total: 1.01s memory: 174592k


### PR DESCRIPTION
Use the latest version of nim available on arch repo

```bash
Main: | Nim | 31.00 ms | 469.88 ms | 4.15 s | 4.65 s |

This PR: | Nim | 22.34 ms | 337.00 ms | 2.95 s | 3.31 s |


Main: | Nim Concurrent | 7.55 ms | 104.09 ms | 902.34 ms | 1.01 s |

This PR: | Nim Concurrent | 6.17 ms | 90.26 ms | 657.74 ms | 754.17 ms |
```